### PR TITLE
feat(debug): Add diagnostic logging to 3D view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ set(LIB_SOURCES
     src/WeatherService.cpp
     src/TerrainService.cpp
     src/ElevationView3D.cpp
+    src/RouteData.cpp
+    src/RouteRenderer.cpp
+    src/FlythroughController.cpp
+    src/build_info.cpp
     src/LandingPage.cpp
     third_party/qcustomplot.cpp
 )
@@ -79,6 +83,9 @@ set(HEADERS
     include/WeatherService.h
     include/TerrainService.h
     include/ElevationView3D.h
+    include/RouteData.h
+    include/RouteRenderer.h
+    include/FlythroughController.h
     include/LandingPage.h
     include/debug_helper.h
     include/build_info.h
@@ -169,12 +176,16 @@ enable_testing()
 
 # Add unit tests
 add_executable(gpxparser_test tests/gpxparser_test.cpp src/GpxParser.cpp)
-target_link_libraries(gpxparser_test PRIVATE Qt5::Test Qt5::Core Qt5::Positioning)
+target_link_libraries(gpxparser_test PRIVATE Qt5::Test Qt5::Core Qt5::Positioning GTest::gtest GTest::gtest_main)
 add_test(NAME GpxParserTest COMMAND gpxparser_test)
 
-add_executable(trackstats_test tests/trackstats_test.cpp src/TrackStatsWidget.cpp src/GpxParser.cpp)
-target_link_libraries(trackstats_test PRIVATE Qt5::Test Qt5::Core Qt5::Widgets Qt5::Positioning)
-add_test(NAME TrackStatsTest COMMAND trackstats_test)
+add_executable(routedata_test tests/routedata_test.cpp src/RouteData.cpp)
+target_link_libraries(routedata_test PRIVATE Qt5::Test Qt5::Core Qt5::Positioning Qt5::Gui)
+add_test(NAME RouteDataTest COMMAND routedata_test -platform offscreen)
+
+add_executable(flythroughcontroller_test tests/flythroughcontroller_test.cpp)
+target_link_libraries(flythroughcontroller_test PRIVATE gpx_viewer_lib Qt5::Test Qt5::Core Qt5::Gui Qt5::Positioning Qt5::3DRender)
+add_test(NAME FlythroughControllerTest COMMAND flythroughcontroller_test -platform offscreen)
 
 # Message about build directory structure
 message(STATUS "Build files will be generated in: ${PROJECT_BINARY_DIR_ABSOLUTE}")

--- a/include/ElevationView3D.h
+++ b/include/ElevationView3D.h
@@ -1,168 +1,67 @@
 #pragma once
 
 #include <QWidget>
-#include <QLabel>
-#include <QPointer>
-#include <Qt3DCore/QEntity>
-#include <Qt3DRender/QCamera>
-#include <Qt3DRender/QMesh>
-#include <Qt3DRender/QMaterial>
-#include <Qt3DExtras/Qt3DWindow>
-#include <Qt3DExtras/QForwardRenderer>
-#include <Qt3DExtras/QPhongMaterial>
-#include <Qt3DExtras/QCylinderMesh>
-#include <Qt3DExtras/QSphereMesh>
-#include <QPropertyAnimation>
-#include <QVector3D>
-#include <QTimer>
-#include <QElapsedTimer>
 #include <vector>
-#include <memory>
 #include "GpxParser.h"
 #include "TerrainService.h"
+#include <QPushButton>
+#include <QSlider>
 
-/**
- * @brief Widget for 3D visualization of elevation profiles
- * 
- * This class provides a 3D view of the route with realistic terrain 
- * representation and fly-through animation capabilities.
- */
+// Forward declarations for our new architecture
+class RouteData;
+class RouteRenderer;
+class FlythroughController;
+namespace Qt3DExtras {
+    class Qt3DWindow;
+    class QOrbitCameraController;
+}
+namespace Qt3DCore { class QEntity; }
+
 class ElevationView3D : public QWidget {
     Q_OBJECT
-    
+
 public:
     explicit ElevationView3D(QWidget* parent = nullptr);
     ~ElevationView3D();
-    
-    /**
-     * @brief Set the GPX track data for 3D visualization
-     * @param points Track points to visualize
-     */
+
+    // Public API used by MainWindow
     void setTrackData(const std::vector<TrackPoint>& points);
-    
-    /**
-     * @brief Process track data in a deferred manner to prevent UI freezing
-     * @param points Track points to visualize
-     */
-    void processTrackDataDeferred(const std::vector<TrackPoint>& points);
-    
-    /**
-     * @brief Update the current position marker
-     * @param pointIndex Index of the current point on the track
-     */
     void updatePosition(size_t pointIndex);
-    
-public slots:
-    /**
-     * @brief Start fly-through animation along the route
-     */
-    void startFlythrough();
-    
-    /**
-     * @brief Pause fly-through animation
-     */
-    void pauseFlythrough();
-    
-    /**
-     * @brief Stop fly-through animation and reset camera
-     */
-    void stopFlythrough();
-    
-    /**
-     * @brief Toggle between first-person and overview camera modes
-     */
-    void toggleCameraMode();
-    
-    /**
-     * @brief Change the vertical scale factor for elevation
-     * @param scale Elevation scale factor (1.0 = actual scale)
-     */
     void setElevationScale(float scale);
-    
-    /**
-     * @brief Set camera tilt angle for first-person view
-     * @param angle Tilt angle in degrees (0 = level, 90 = looking down)
-     */
-    void setCameraTilt(float angle);
-    
+
 signals:
-    /**
-     * @brief Signal emitted when position changes during fly-through
-     * @param pointIndex Index of the current position
-     */
+    // Public signal used by MainWindow
     void positionChanged(int pointIndex);
-    
+
 private slots:
-    void updateFlythrough();
-    void updateAnimationSpeed();
-    void updateFPS();
+    void onPlayPause(bool checked);
     void onTerrainDataReady(const TerrainData& data);
-    
+
 private:
+    void setupUi();
+    void resetCameraView();
+
+    // Main Qt3D components
+    Qt3DExtras::Qt3DWindow* m_3dWindow;
+    Qt3DCore::QEntity* m_rootEntity;
+
+    // New modular components
+    RouteData* m_routeData;
+    RouteRenderer* m_routeRenderer;
+    FlythroughController* m_flythroughController;
+    Qt3DCore::QEntity* m_markerEntity;
+    Qt3DExtras::QOrbitCameraController* m_orbitController;
+    Qt3DCore::QEntity* m_terrainEntity;
+
     // Services
     TerrainService* m_terrainService;
 
-    // Qt3D setup
-    Qt3DExtras::Qt3DWindow* m_3dWindow;
-    Qt3DCore::QEntity* m_rootEntity;
-    Qt3DRender::QCamera* m_camera;
-    Qt3DCore::QEntity* m_terrainEntity;
-    Qt3DCore::QEntity* m_routeEntity;
-    Qt3DCore::QEntity* m_markerEntity;
-    
-    // Track data
-    std::vector<QVector3D> m_trackPositions;
+    // Data
     std::vector<TrackPoint> m_trackPoints;
-    size_t m_currentPositionIndex;
-    
-    // Animation
-    QTimer* m_flythroughTimer;
-    bool m_flythroughActive;
-    float m_flythroughSpeed;
-    float m_flythroughProgress;
-    int m_animSegment;
-    
-    // Configuration
-    bool m_firstPersonMode;
     float m_elevationScale;
-    float m_cameraTilt;
-    
-    // Performance monitoring
-    QElapsedTimer m_frameCounter;
-    int m_frameCount;
-    double m_fps;
-    bool m_showDebugInfo;  // Reordered to fix initialization order warning
-    QLabel* m_debugInfoLabel;
-    QTimer* m_fpsTimer;
-    qint64 m_lastUpdateTime;  // Moved this after m_showDebugInfo
-    
-    // Override event handling for frame counting
-    bool event(QEvent* event) override;
-    
-    // Helper methods
-    void setupUI();
-    void setupCamera();
-    
-    // Memory-safe entity management methods
-    void safelyCleanupEntities();
-    void convertTrackPointsTo3D(const std::vector<TrackPoint>& points);
-    void createSceneEntities();
-    void resetCameraView();
-    
-    // Entity creation methods
-    void createTerrain();
-    void createRoute();
-    void createMarker();
-    Qt3DCore::QEntity* createTerrainMesh(const TerrainData& terrainData);
-    Qt3DCore::QEntity* createOptimizedRoutePath(const std::vector<TrackPoint>& points);
-    void createBatchedSegments(Qt3DCore::QEntity* parentEntity, const std::vector<TrackPoint>& points,
-                             size_t startIdx, size_t endIdx);
-    void simplifyRoute(const std::vector<TrackPoint>& input, std::vector<TrackPoint>& output, int maxPoints);
-    Qt3DCore::QEntity* createPositionMarker();
-    
-    // Utility methods
-    void updateMarkerPosition(size_t pointIndex);
-    QVector3D trackPointToVector3D(const TrackPoint& point, bool scaleElevation = true);
-    void setCameraPosition(const QVector3D& position, const QVector3D& target);
-    size_t findClosestPointOnRoute(float progress);
+
+    // UI Elements
+    QPushButton* m_playPauseButton;
+    QPushButton* m_stopButton;
+    QSlider* m_speedSlider;
 };

--- a/include/ElevationView3D_old.h
+++ b/include/ElevationView3D_old.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <QWidget>
+#include <QLabel>
+#include <QPointer>
+#include <Qt3DCore/QEntity>
+#include <Qt3DRender/QCamera>
+#include <Qt3DRender/QMesh>
+#include <Qt3DRender/QMaterial>
+#include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DExtras/QForwardRenderer>
+#include <Qt3DExtras/QPhongMaterial>
+#include <Qt3DExtras/QCylinderMesh>
+#include <Qt3DExtras/QSphereMesh>
+#include <QPropertyAnimation>
+#include <QVector3D>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <vector>
+#include <memory>
+#include "GpxParser.h"
+#include "TerrainService.h"
+
+/**
+ * @brief Widget for 3D visualization of elevation profiles
+ *
+ * This class provides a 3D view of the route with realistic terrain
+ * representation and fly-through animation capabilities.
+ */
+class ElevationView3D : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ElevationView3D(QWidget* parent = nullptr);
+    ~ElevationView3D();
+
+    /**
+     * @brief Set the GPX track data for 3D visualization
+     * @param points Track points to visualize
+     */
+    void setTrackData(const std::vector<TrackPoint>& points);
+
+    /**
+     * @brief Process track data in a deferred manner to prevent UI freezing
+     * @param points Track points to visualize
+     */
+    void processTrackDataDeferred(const std::vector<TrackPoint>& points);
+
+    /**
+     * @brief Update the current position marker
+     * @param pointIndex Index of the current point on the track
+     */
+    void updatePosition(size_t pointIndex);
+
+public slots:
+    /**
+     * @brief Start fly-through animation along the route
+     */
+    void startFlythrough();
+
+    /**
+     * @brief Pause fly-through animation
+     */
+    void pauseFlythrough();
+
+    /**
+     * @brief Stop fly-through animation and reset camera
+     */
+    void stopFlythrough();
+
+    /**
+     * @brief Toggle between first-person and overview camera modes
+     */
+    void toggleCameraMode();
+
+    /**
+     * @brief Change the vertical scale factor for elevation
+     * @param scale Elevation scale factor (1.0 = actual scale)
+     */
+    void setElevationScale(float scale);
+
+    /**
+     * @brief Set camera tilt angle for first-person view
+     * @param angle Tilt angle in degrees (0 = level, 90 = looking down)
+     */
+    void setCameraTilt(float angle);
+
+signals:
+    /**
+     * @brief Signal emitted when position changes during fly-through
+     * @param pointIndex Index of the current position
+     */
+    void positionChanged(int pointIndex);
+
+private slots:
+    void updateFlythrough();
+    void updateAnimationSpeed();
+    void updateFPS();
+    void onTerrainDataReady(const TerrainData& data);
+
+private:
+    // Services
+    TerrainService* m_terrainService;
+
+    // Qt3D setup
+    Qt3DExtras::Qt3DWindow* m_3dWindow;
+    Qt3DCore::QEntity* m_rootEntity;
+    Qt3DRender::QCamera* m_camera;
+    Qt3DCore::QEntity* m_terrainEntity;
+    Qt3DCore::QEntity* m_routeEntity;
+    Qt3DCore::QEntity* m_markerEntity;
+
+    // Track data
+    std::vector<QVector3D> m_trackPositions;
+    std::vector<TrackPoint> m_trackPoints;
+    size_t m_currentPositionIndex;
+
+    // Animation
+    QTimer* m_flythroughTimer;
+    bool m_flythroughActive;
+    float m_flythroughSpeed;
+    float m_flythroughProgress;
+    int m_animSegment;
+
+    // Configuration
+    bool m_firstPersonMode;
+    float m_elevationScale;
+    float m_cameraTilt;
+
+    // Performance monitoring
+    QElapsedTimer m_frameCounter;
+    int m_frameCount;
+    double m_fps;
+    bool m_showDebugInfo;  // Reordered to fix initialization order warning
+    QLabel* m_debugInfoLabel;
+    QTimer* m_fpsTimer;
+    qint64 m_lastUpdateTime;  // Moved this after m_showDebugInfo
+
+    // Override event handling for frame counting
+    bool event(QEvent* event) override;
+
+    // Helper methods
+    void setupUI();
+    void setupCamera();
+
+    // Memory-safe entity management methods
+    void safelyCleanupEntities();
+    void convertTrackPointsTo3D(const std::vector<TrackPoint>& points);
+    void createSceneEntities();
+    void resetCameraView();
+
+    // Entity creation methods
+    void createTerrain();
+    void createRoute();
+    void createMarker();
+    Qt3DCore::QEntity* createTerrainMesh(const TerrainData& terrainData);
+    Qt3DCore::QEntity* createOptimizedRoutePath(const std::vector<TrackPoint>& points);
+    void createBatchedSegments(Qt3DCore::QEntity* parentEntity, const std::vector<TrackPoint>& points,
+                             size_t startIdx, size_t endIdx);
+    void simplifyRoute(const std::vector<TrackPoint>& input, std::vector<TrackPoint>& output, int maxPoints);
+    Qt3DCore::QEntity* createPositionMarker();
+
+    // Utility methods
+    void updateMarkerPosition(size_t pointIndex);
+    QVector3D trackPointToVector3D(const TrackPoint& point, bool scaleElevation = true);
+    void setCameraPosition(const QVector3D& position, const QVector3D& target);
+    size_t findClosestPointOnRoute(float progress);
+};

--- a/include/FlythroughController.h
+++ b/include/FlythroughController.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "RouteData.h"
+#include <QObject>
+
+namespace Qt3DRender { class QCamera; }
+class QTimer;
+
+class FlythroughController : public QObject {
+    Q_OBJECT
+
+public:
+    FlythroughController(RouteData* routeData, Qt3DRender::QCamera* camera, QObject* parent = nullptr);
+    ~FlythroughController();
+
+public slots:
+    void start();
+    void pause();
+    void stop();
+    void setSpeed(float speed);
+
+signals:
+    void positionChanged(int pointIndex);
+
+private slots:
+    void updateAnimation();
+
+private:
+    RouteData* m_routeData;
+    Qt3DRender::QCamera* m_camera;
+
+    // Animation state
+    QTimer* m_timer;
+    bool m_isActive;
+    float m_progress; // 0.0 to 1.0
+    float m_speed;
+};

--- a/include/RouteData.h
+++ b/include/RouteData.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "GpxParser.h"
+#include <vector>
+#include <QVector3D>
+
+struct RoutePoint {
+    QVector3D position;
+    QVector3D direction;
+    float distance; // Cumulative distance from the start
+};
+
+class RouteData {
+public:
+    RouteData(const std::vector<TrackPoint>& trackPoints, float elevationScale = 1.0f);
+    ~RouteData();
+
+    const std::vector<QVector3D>& getPositions() const { return m_positions; }
+    RoutePoint getPointAtProgress(float progress) const;
+    size_t getIndexAtProgress(float progress) const;
+
+private:
+    void processPoints(const std::vector<TrackPoint>& trackPoints, float elevationScale);
+
+    std::vector<QVector3D> m_positions; // Raw positions, for renderer
+    std::vector<RoutePoint> m_routePoints; // Enriched points for controller
+    float m_totalDistance = 0.0f;
+};

--- a/include/RouteRenderer.h
+++ b/include/RouteRenderer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "RouteData.h"
+#include <Qt3DCore/QEntity>
+
+class RouteRenderer {
+public:
+    RouteRenderer(RouteData* routeData, Qt3DCore::QEntity* parentEntity);
+    ~RouteRenderer();
+
+    Qt3DCore::QEntity* getEntity() const { return m_entity; }
+
+private:
+    void generateMesh();
+
+    RouteData* m_routeData;
+    Qt3DCore::QEntity* m_entity;
+};

--- a/src/ElevationView3D.cpp
+++ b/src/ElevationView3D.cpp
@@ -1,709 +1,328 @@
 #include "ElevationView3D.h"
 #include "logging.h"
-#include "TerrainService.h"
+#include "RouteData.h"
+#include "RouteRenderer.h"
+#include "FlythroughController.h"
 #include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QPushButton>
-#include <QSlider>
-#include <QLabel>
-#include <QGroupBox>
-#include <QStyle>
-#include <QDebug>
-#include <Qt3DExtras/QDiffuseSpecularMaterial>
-#include <Qt3DRender/QTexture>
-#include <Qt3DExtras/QPhongAlphaMaterial>
-#include <Qt3DExtras/QOrbitCameraController>
-#include <Qt3DExtras/QFirstPersonCameraController>
+#include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DExtras/QForwardRenderer>
+#include <Qt3DCore/QEntity>
+#include <Qt3DRender/QCamera>
 #include <Qt3DRender/QPointLight>
-#include <Qt3DRender/QRenderSettings>
-#include <Qt3DExtras/QCuboidMesh>
 #include <Qt3DCore/QTransform>
-#include <Qt3DExtras/QExtrudedTextMesh>
-#include <QCoreApplication>
-#include <cmath>
-#include <algorithm>
-#include <limits>
-#include <QElapsedTimer>
+#include <Qt3DExtras/QOrbitCameraController>
+#include <Qt3DExtras/QSphereMesh>
+#include <Qt3DExtras/QPlaneMesh>
+#include <Qt3DExtras/QPhongMaterial>
+#include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DRender/QAttribute>
 #include <Qt3DRender/QBuffer>
-#include <Qt3DRender/QGeometry>
-#include <Qt3DRender/QGeometryRenderer>
-#include <QRandomGenerator>
+#include <QHBoxLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QStyle>
+#include <cmath>
+#include <QVector2D>
 
-// Constants for 3D visualization with optimization settings
 namespace {
-    const float DEFAULT_ELEVATION_SCALE = 2.0f;
-    const float TERRAIN_WIDTH = 1000.0f;
-    const float MARKER_SIZE = 2.0f;
-    const float DEFAULT_CAMERA_TILT = 30.0f;
-    const int DEFAULT_FLYTHROUGH_INTERVAL = 50; // milliseconds
-    const float DEFAULT_FLYTHROUGH_SPEED = 0.0015f; // progress per update
-    
-    // Performance optimization parameters
-    const int ROUTE_SEGMENT_BATCH_SIZE = 25; // Batch this many segments into a single mesh
-    const int MAX_ROUTE_VERTICES = 5000; // Maximum number of vertices for route
-    const int LOD_DISTANCE_THRESHOLD = 200; // Use lower detail for segments farther than this
-    const int FPS_UPDATE_INTERVAL = 1000; // Update FPS display every second
-    const bool ENABLE_CULLING = true; // Enable culling of segments outside view frustum
-    
-    #ifndef M_PI
-    const double M_PI = 3.14159265358979323846;
-    #endif
+    // Constants for coordinate conversion
+    constexpr double EARTH_RADIUS_METERS = 6378137.0;
+
+    // Function to convert latitude/longitude to local X/Z coordinates using Mercator projection
+    QVector2D lonLatToMercator(double lon, double lat, double originLon, double originLat) {
+        double x = EARTH_RADIUS_METERS * (lon - originLon) * (M_PI / 180.0) * std::cos(originLat * (M_PI / 180.0));
+        double z = EARTH_RADIUS_METERS * (lat - originLat) * (M_PI / 180.0);
+        return QVector2D(static_cast<float>(x), static_cast<float>(z));
+    }
 }
+
 
 ElevationView3D::ElevationView3D(QWidget* parent)
     : QWidget(parent),
-      m_currentPositionIndex(0),
-      m_flythroughActive(false),
-      m_flythroughSpeed(DEFAULT_FLYTHROUGH_SPEED),
-      m_flythroughProgress(0.0f),
-      m_animSegment(0),
-      m_firstPersonMode(false),
-      m_elevationScale(DEFAULT_ELEVATION_SCALE),
-      m_cameraTilt(DEFAULT_CAMERA_TILT),
-      m_frameCount(0),
-      m_fps(0),
-      m_showDebugInfo(false),
-      m_lastUpdateTime(0)
+      m_3dWindow(new Qt3DExtras::Qt3DWindow()),
+      m_rootEntity(new Qt3DCore::QEntity()),
+      m_routeData(nullptr),
+      m_routeRenderer(nullptr),
+      m_flythroughController(nullptr),
+      m_markerEntity(nullptr),
+      m_terrainEntity(nullptr),
+      m_terrainService(new TerrainService(this)),
+      m_elevationScale(1.0f),
+      m_playPauseButton(nullptr),
+      m_stopButton(nullptr),
+      m_speedSlider(nullptr)
 {
-    setupUI();
-    
-    // Initialize terrain service
-    m_terrainService = new TerrainService(this);
+    logDebug("ElevationView3D", "Initializing new ElevationView3D");
     connect(m_terrainService, &TerrainService::terrainDataReady, this, &ElevationView3D::onTerrainDataReady);
-    connect(m_terrainService, &TerrainService::error, [](const QString& errorMessage) {
-        logWarning("TerrainService", errorMessage);
-    });
-
-    // Initialize animation timer
-    m_flythroughTimer = new QTimer(this);
-    m_flythroughTimer->setInterval(DEFAULT_FLYTHROUGH_INTERVAL);
-    connect(m_flythroughTimer, &QTimer::timeout, this, &ElevationView3D::updateFlythrough);
-    
-    // Initialize FPS timer
-    m_fpsTimer = new QTimer(this);
-    m_fpsTimer->setInterval(FPS_UPDATE_INTERVAL);
-    connect(m_fpsTimer, &QTimer::timeout, this, &ElevationView3D::updateFPS);
-    m_fpsTimer->start();
-    
-    // Performance monitoring
-    m_frameCounter.start();
+    setupUi();
 }
 
 ElevationView3D::~ElevationView3D()
 {
-    // Clean up is handled automatically through Qt parent/child relationships
+    logDebug("ElevationView3D", "Destroying ElevationView3D");
+    // UI elements are managed by Qt's parent-child system.
+    // We still need to manage our custom objects.
+    delete m_routeData;
+    delete m_routeRenderer;
+    delete m_flythroughController;
 }
 
-void ElevationView3D::setupUI()
+void ElevationView3D::setupUi()
 {
-    // Create main layout
+    // Main layout
     QVBoxLayout* mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(0, 0, 0, 0);
-    
-    // Create 3D window
-    m_3dWindow = new Qt3DExtras::Qt3DWindow();
+
+    // Create a container for the 3D window
+    QWidget* container = QWidget::createWindowContainer(m_3dWindow);
+    container->setMinimumSize(640, 480);
+    mainLayout->addWidget(container, 1);
+
+    // --- Control Panel ---
+    auto* controlPanel = new QGroupBox("Animation Controls", this);
+    auto* controlLayout = new QHBoxLayout(controlPanel);
+
+    m_playPauseButton = new QPushButton(this);
+    m_playPauseButton->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+    m_playPauseButton->setToolTip("Start/Pause Flythrough");
+    m_playPauseButton->setCheckable(true);
+    m_playPauseButton->setEnabled(false);
+    controlLayout->addWidget(m_playPauseButton);
+
+    m_stopButton = new QPushButton(this);
+    m_stopButton->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
+    m_stopButton->setToolTip("Stop Flythrough");
+    m_stopButton->setEnabled(false);
+    controlLayout->addWidget(m_stopButton);
+
+    auto* overviewButton = new QPushButton("Overview", this);
+    controlLayout->addWidget(overviewButton);
+    connect(overviewButton, &QPushButton::clicked, this, [this](){
+        m_orbitController->setEnabled(true);
+        resetCameraView();
+    });
+
+    controlLayout->addWidget(new QLabel("Speed:", this));
+    m_speedSlider = new QSlider(Qt::Horizontal, this);
+    m_speedSlider->setRange(1, 20); // 0.1x to 2.0x speed
+    m_speedSlider->setValue(10);
+    m_speedSlider->setEnabled(false);
+    controlLayout->addWidget(m_speedSlider);
+
+    mainLayout->addWidget(controlPanel);
+
+
+    // Basic scene setup
+    m_3dWindow->setRootEntity(m_rootEntity);
     m_3dWindow->defaultFrameGraph()->setClearColor(QColor(210, 230, 255));
-    
-    // Create root entity
-    m_rootEntity = new Qt3DCore::QEntity();
-    
-    // Create camera
-    m_camera = m_3dWindow->camera();
-    m_camera->lens()->setPerspectiveProjection(45.0f, 16.0f/9.0f, 0.1f, 1000.0f);
-    m_camera->setPosition(QVector3D(0, 80, 80));
-    m_camera->setViewCenter(QVector3D(0, 0, 0));
-    m_camera->setUpVector(QVector3D(0, 1, 0));
-    
-    // Add camera controller
-    setupCamera();
-    
+
+    // Camera
+    Qt3DRender::QCamera* camera = m_3dWindow->camera();
+    camera->lens()->setPerspectiveProjection(45.0f, 16.0f / 9.0f, 0.1f, 10000.0f); // Increased far plane
+    camera->setPosition(QVector3D(0, 40, 80));
+    camera->setViewCenter(QVector3D(0, 0, 0));
+
+    // Add a camera controller for easy navigation
+    m_orbitController = new Qt3DExtras::QOrbitCameraController(m_rootEntity);
+    m_orbitController->setCamera(camera);
+    m_orbitController->setLinearSpeed(200.0f); // Adjust speed for larger scenes
+    m_orbitController->setLookSpeed(180.0f);
+
     // Add global light
-    Qt3DCore::QEntity* lightEntity = new Qt3DCore::QEntity(m_rootEntity);
-    Qt3DRender::QPointLight* light = new Qt3DRender::QPointLight(lightEntity);
+    auto* lightEntity = new Qt3DCore::QEntity(m_rootEntity);
+    auto* light = new Qt3DRender::QPointLight(lightEntity);
     light->setColor(QColor(255, 255, 255));
     light->setIntensity(1.0f);
     lightEntity->addComponent(light);
-    
-    Qt3DCore::QTransform* lightTransform = new Qt3DCore::QTransform(lightEntity);
-    lightTransform->setTranslation(QVector3D(0, 150, 0));
+    auto* lightTransform = new Qt3DCore::QTransform(lightEntity);
+    lightTransform->setTranslation(QVector3D(0, 500, 0));
     lightEntity->addComponent(lightTransform);
-    
-    // Set root entity
-    m_3dWindow->setRootEntity(m_rootEntity);
-    
-    // Create container widget for 3D window
-    QWidget* container = QWidget::createWindowContainer(m_3dWindow);
-    container->setMinimumSize(640, 480);
-    container->setFocusPolicy(Qt::StrongFocus);
-    mainLayout->addWidget(container, 1);
-    
-    // Create control panel
-    QGroupBox* controlPanel = new QGroupBox("3D Controls", this);
-    QVBoxLayout* controlLayout = new QVBoxLayout(controlPanel);
-    controlLayout->setContentsMargins(8, 8, 8, 8);
-    controlLayout->setSpacing(4);
-    
-    // Create camera controls
-    QHBoxLayout* cameraLayout = new QHBoxLayout();
-    QPushButton* cameraToggleButton = new QPushButton("Toggle Camera Mode", this);
-    connect(cameraToggleButton, &QPushButton::clicked, this, &ElevationView3D::toggleCameraMode);
-    cameraLayout->addWidget(cameraToggleButton);
-    
-    // Elevation scale control
-    QLabel* scaleLabel = new QLabel("Elevation Scale:", this);
-    QSlider* scaleSlider = new QSlider(Qt::Horizontal, this);
-    scaleSlider->setRange(10, 50);
-    scaleSlider->setValue(m_elevationScale * 10);
-    scaleSlider->setTickPosition(QSlider::TicksBelow);
-    connect(scaleSlider, &QSlider::valueChanged, [this](int value) {
-        setElevationScale(value / 10.0f);
-    });
-    cameraLayout->addWidget(scaleLabel);
-    cameraLayout->addWidget(scaleSlider, 1);
-    
-    controlLayout->addLayout(cameraLayout);
-    
-    // Create flythrough controls
-    QHBoxLayout* flythroughLayout = new QHBoxLayout();
-    
-    QPushButton* startButton = new QPushButton(this);
-    startButton->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
-    startButton->setToolTip("Start Flythrough");
-    connect(startButton, &QPushButton::clicked, this, &ElevationView3D::startFlythrough);
-    flythroughLayout->addWidget(startButton);
-    
-    QPushButton* pauseButton = new QPushButton(this);
-    pauseButton->setIcon(style()->standardIcon(QStyle::SP_MediaPause));
-    pauseButton->setToolTip("Pause Flythrough");
-    connect(pauseButton, &QPushButton::clicked, this, &ElevationView3D::pauseFlythrough);
-    flythroughLayout->addWidget(pauseButton);
-    
-    QPushButton* stopButton = new QPushButton(this);
-    stopButton->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
-    stopButton->setToolTip("Stop Flythrough");
-    connect(stopButton, &QPushButton::clicked, this, &ElevationView3D::stopFlythrough);
-    flythroughLayout->addWidget(stopButton);
-    
-    // Speed control
-    QLabel* speedLabel = new QLabel("Speed:", this);
-    QSlider* speedSlider = new QSlider(Qt::Horizontal, this);
-    speedSlider->setRange(1, 10);
-    speedSlider->setValue(5);
-    speedSlider->setTickPosition(QSlider::TicksBelow);
-    connect(speedSlider, &QSlider::valueChanged, [this](int value) {
-        m_flythroughSpeed = DEFAULT_FLYTHROUGH_SPEED * (value / 5.0f);
-        updateAnimationSpeed();
-    });
-    
-    flythroughLayout->addWidget(speedLabel);
-    flythroughLayout->addWidget(speedSlider, 1);
-    
-    controlLayout->addLayout(flythroughLayout);
-    
-    // Camera tilt control (for first-person mode)
-    QHBoxLayout* tiltLayout = new QHBoxLayout();
-    QLabel* tiltLabel = new QLabel("Camera Tilt:", this);
-    QSlider* tiltSlider = new QSlider(Qt::Horizontal, this);
-    tiltSlider->setRange(0, 90);
-    tiltSlider->setValue(m_cameraTilt);
-    tiltSlider->setTickPosition(QSlider::TicksBelow);
-    connect(tiltSlider, &QSlider::valueChanged, [this](int value) {
-        setCameraTilt(value);
-    });
-    
-    tiltLayout->addWidget(tiltLabel);
-    tiltLayout->addWidget(tiltSlider, 1);
-    
-    controlLayout->addLayout(tiltLayout);
-    
-    // Add debug info label
-    m_debugInfoLabel = new QLabel(this);
-    m_debugInfoLabel->setStyleSheet("background-color: rgba(0,0,0,120); color: white; padding: 4px; font-family: monospace;");
-    m_debugInfoLabel->setAlignment(Qt::AlignLeft | Qt::AlignTop);
-    m_debugInfoLabel->setVisible(m_showDebugInfo);
-    
-    // Add toggle for debug info
-    QHBoxLayout* debugLayout = new QHBoxLayout();
-    QPushButton* debugButton = new QPushButton("Toggle Performance Info", this);
-    connect(debugButton, &QPushButton::clicked, [this]() {
-        m_showDebugInfo = !m_showDebugInfo;
-        m_debugInfoLabel->setVisible(m_showDebugInfo);
-    });
-    debugLayout->addWidget(debugButton);
-    controlLayout->addLayout(debugLayout);
-    
-    mainLayout->addWidget(controlPanel);
-}
 
-void ElevationView3D::setupCamera()
-{
-    // Remove any existing controller
-    for (Qt3DCore::QComponent* component : m_camera->components()) {
-        m_camera->removeComponent(component);
-    }
-    
-    if (m_firstPersonMode) {
-        // First person camera controller (for flythrough)
-        Qt3DExtras::QFirstPersonCameraController* camController = new Qt3DExtras::QFirstPersonCameraController(m_rootEntity);
-        camController->setCamera(m_camera);
-        camController->setLinearSpeed(50.0f);
-        camController->setLookSpeed(180.0f);
-    } else {
-        // Orbit camera controller (for overview)
-        Qt3DExtras::QOrbitCameraController* camController = new Qt3DExtras::QOrbitCameraController(m_rootEntity);
-        camController->setCamera(m_camera);
-        camController->setLinearSpeed(50.0f);
-        camController->setLookSpeed(180.0f);
-    }
+    // Create marker entity
+    m_markerEntity = new Qt3DCore::QEntity(m_rootEntity);
+    auto* markerMesh = new Qt3DExtras::QSphereMesh();
+    markerMesh->setRadius(2.0f);
+    auto* markerMaterial = new Qt3DExtras::QPhongMaterial();
+    markerMaterial->setDiffuse(QColor(QRgb(0xFF0000)));
+    auto* markerTransform = new Qt3DCore::QTransform();
+    m_markerEntity->addComponent(markerMesh);
+    m_markerEntity->addComponent(markerMaterial);
+    m_markerEntity->addComponent(markerTransform);
+    m_markerEntity->setEnabled(false); // Initially hidden
 }
 
 void ElevationView3D::setTrackData(const std::vector<TrackPoint>& points)
 {
-    QElapsedTimer totalTimer;
-    totalTimer.start();
-    logInfo("ElevationView3D", QString("Starting 3D track data processing with %1 points").arg(points.size()));
-    
-    if (points.empty()) {
-        logWarning("ElevationView3D", "No points provided, returning");
+    logInfo("ElevationView3D", QString("Setting new track data with %1 points.").arg(points.size()));
+    m_trackPoints = points;
+
+    // 1. Clean up old data
+    delete m_flythroughController;
+    m_flythroughController = nullptr;
+    delete m_routeRenderer;
+    m_routeRenderer = nullptr;
+    delete m_routeData;
+    m_routeData = nullptr;
+    m_markerEntity->setEnabled(false);
+
+    if (m_trackPoints.size() < 2) {
+        logWarning("ElevationView3D", "Not enough points to draw a route.");
+        m_playPauseButton->setEnabled(false);
+        m_stopButton->setEnabled(false);
+        m_speedSlider->setEnabled(false);
         return;
     }
-    
-    // Use a guard flag to prevent reentrancy issues
-    static bool isUpdating = false;
-    if (isUpdating) {
-        logWarning("ElevationView3D", "Already updating, ignoring recursive call");
-        return;
-    }
-    
-    // Set the guard flag
-    isUpdating = true;
-    
-    // Use a single shot timer to defer processing and keep UI responsive
-    if (points.size() > 1000) {
-        logInfo("ElevationView3D", "Large dataset detected, deferring 3D processing");
-        QTimer::singleShot(100, this, [this, points]() {
-            this->processTrackDataDeferred(points);
-        });
-        isUpdating = false;
-        return;
-    }
-    
-    try {
-        // Clear existing track data first to prevent access to invalid memory
-        logDebug("ElevationView3D", "Clearing track positions");
-        m_trackPositions.clear();
-        
-        // Store original track points
-        logDebug("ElevationView3D", "Storing track points");
-        m_trackPoints = points;
-        
-        // Safely clean up existing entities
-        safelyCleanupEntities();
-        
-        // Ensure we have a valid root entity
-        logDebug("ElevationView3D", "Checking root entity");
-        if (!m_rootEntity || m_rootEntity->parent() == nullptr) {
-            logDebug("ElevationView3D", "Creating new root entity");
-            m_rootEntity = new Qt3DCore::QEntity();
-            if (m_3dWindow) {
-                m_3dWindow->setRootEntity(m_rootEntity);
-            } else {
-                logWarning("ElevationView3D", "No 3D window available");
-                isUpdating = false; // Reset guard flag
-                return;
-            }
-        }
-        
-        // Convert track points to 3D positions
-        convertTrackPointsTo3D(points);
-        
-        // Create new terrain and route entities
-        createSceneEntities();
-        
-        // Fetch terrain data
-        if (!m_trackPoints.empty()) {
-            double minLat = m_trackPoints[0].coord.latitude();
-            double maxLat = m_trackPoints[0].coord.latitude();
-            double minLon = m_trackPoints[0].coord.longitude();
-            double maxLon = m_trackPoints[0].coord.longitude();
-            for (const auto& point : m_trackPoints) {
-                minLat = std::min(minLat, point.coord.latitude());
-                maxLat = std::max(maxLat, point.coord.latitude());
-                minLon = std::min(minLon, point.coord.longitude());
-                maxLon = std::max(maxLon, point.coord.longitude());
-            }
-            // Add a small buffer around the track
-            double latBuffer = (maxLat - minLat) * 0.1;
-            double lonBuffer = (maxLon - minLon) * 0.1;
-            m_terrainService->fetchTerrainData(maxLat + latBuffer, minLat - latBuffer, minLon - lonBuffer, maxLon + lonBuffer, 100, 100);
-        }
 
-        // Reset camera to view the entire route
-        resetCameraView();
-        
-        logDebug("ElevationView3D", "Completed successfully");
-    } catch (const std::exception& e) {
-        logCritical("ElevationView3D", QString("Exception during processing: %1").arg(e.what()));
-    } catch (...) {
-        logCritical("ElevationView3D", "Unknown exception during processing");
-    }
-    
-    // Reset the guard flag
-    isUpdating = false;
-    
-    // The guard flag will be automatically reset when this function exits
-}
+    // 2. Create data and renderer
+    m_routeData = new RouteData(m_trackPoints, m_elevationScale);
+    m_routeRenderer = new RouteRenderer(m_routeData, m_rootEntity);
 
-// New method to defer processing of large track data sets to keep UI responsive
-void ElevationView3D::processTrackDataDeferred(const std::vector<TrackPoint>& points)
-{
-    QElapsedTimer totalTimer;
-    totalTimer.start();
-    static bool isUpdating = false;
+    // 3. Create controller and connect UI
+    m_flythroughController = new FlythroughController(m_routeData, m_3dWindow->camera(), this);
     
-    if (isUpdating) {
-        logWarning("ElevationView3D", "Already processing in deferred mode, skipping");
-        return;
-    }
-    
-    isUpdating = true;
-    
-    try {
-        // Clear existing track data first to prevent access to invalid memory
-        logDebug("ElevationView3D", "Clearing track positions");
-        m_trackPositions.clear();
-        QCoreApplication::processEvents();
-        
-        // Store original track points
-        logDebug("ElevationView3D", "Storing track points");
-        m_trackPoints = points;
-        QCoreApplication::processEvents();
-        
-        // Safely clean up existing entities
-        safelyCleanupEntities();
-        QCoreApplication::processEvents();
-        
-        // Ensure we have a valid root entity
-        logDebug("ElevationView3D", "Checking root entity");
-        if (!m_rootEntity || m_rootEntity->parent() == nullptr) {
-            logDebug("ElevationView3D", "Creating new root entity");
-            m_rootEntity = new Qt3DCore::QEntity();
-            if (m_3dWindow) {
-                m_3dWindow->setRootEntity(m_rootEntity);
-            } else {
-                logWarning("ElevationView3D", "No 3D window available");
-                isUpdating = false; // Reset guard flag
-                return;
-            }
-        }
-        QCoreApplication::processEvents();
-        
-        // Convert track points to 3D positions - this can be intensive
-        QElapsedTimer timer;
-        timer.start();
-        logInfo("ElevationView3D", "Converting track points to 3D positions...");
-        convertTrackPointsTo3D(points);
-        logInfo("ElevationView3D", QString("Conversion completed in %1 ms").arg(timer.elapsed()));
-        QCoreApplication::processEvents();
-        
-        // Create new terrain and route entities in stages
-        timer.restart();
-        logInfo("ElevationView3D", "Creating scene entities...");
-        createSceneEntities();
-        logInfo("ElevationView3D", QString("Scene creation completed in %1 ms").arg(timer.elapsed()));
-        QCoreApplication::processEvents();
-        
-        // Reset camera to view the entire route
-        timer.restart();
-        logInfo("ElevationView3D", "Resetting camera view...");
-        resetCameraView();
-        logInfo("ElevationView3D", QString("Camera reset completed in %1 ms").arg(timer.elapsed()));
-        
-        logInfo("ElevationView3D", QString("Total 3D processing completed in %1 ms").arg(totalTimer.elapsed()));
-    } catch (const std::exception& e) {
-        logCritical("ElevationView3D", QString("Exception during deferred processing: %1").arg(e.what()));
-    } catch (...) {
-        logCritical("ElevationView3D", "Unknown exception during deferred processing");
-    }
-    
-    // Reset the guard flag
-    isUpdating = false;
-}
+    connect(m_playPauseButton, &QPushButton::toggled, this, &ElevationView3D::onPlayPause);
+    connect(m_stopButton, &QPushButton::clicked, m_flythroughController, &FlythroughController::stop);
+    connect(m_stopButton, &QPushButton::clicked, this, [this](){
+        m_orbitController->setEnabled(true);
+        m_playPauseButton->setChecked(false);
+    });
+    connect(m_speedSlider, &QSlider::valueChanged, this, [this](int value) {
+        m_flythroughController->setSpeed(value / 10.0f);
+    });
 
-void ElevationView3D::safelyCleanupEntities()
-{
-    qDebug() << "ElevationView3D::safelyCleanupEntities - Starting cleanup";
-    
-    // Use standard approach without QPointer
-    QList<Qt3DCore::QEntity*> entitiesToDelete;
-    
-    if (m_terrainEntity) {
-        entitiesToDelete.append(m_terrainEntity);
-        m_terrainEntity = nullptr;
-    }
-    
-    if (m_routeEntity) {
-        entitiesToDelete.append(m_routeEntity);
-        m_routeEntity = nullptr;
-    }
-    
-    if (m_markerEntity) {
-        entitiesToDelete.append(m_markerEntity);
-        m_markerEntity = nullptr;
-    }
-    
-    // Process deletions more safely to avoid reentrancy and segfault issues
-    if (!entitiesToDelete.isEmpty()) {
-        // Critical fix: Create a heap-allocated copy of the entity list
-        // This ensures the entity list survives beyond this method's scope
-        auto* deleteList = new QList<Qt3DCore::QEntity*>(entitiesToDelete);
-        
-        // Use a QObject to own the lambda, ensuring it's deleted after execution
-        QObject* cleanupHandler = new QObject(this);
-        // Use the C++11 lambda syntax that captures the deleteList by value
-        QTimer::singleShot(0, cleanupHandler, [cleanupHandler, deleteList]() {
-            // Process each entity in our heap-allocated list
-            for (Qt3DCore::QEntity* entity : *deleteList) {
-                if (entity) {
-                    // Just schedule deletion without modifying the entity
-                    entity->deleteLater();
-                }
-            }
-            // Clean up our heap-allocated list and the cleanup handler
-            delete deleteList;
-            cleanupHandler->deleteLater();
-        });
-    }
-    
-    qDebug() << "ElevationView3D::safelyCleanupEntities - Scheduled" << entitiesToDelete.size() 
-             << "entities for deletion";
-}
+    // Propagate signal to MainWindow and update marker
+    connect(m_flythroughController, &FlythroughController::positionChanged, this, &ElevationView3D::positionChanged);
+    connect(m_flythroughController, &FlythroughController::positionChanged, this, &ElevationView3D::updatePosition);
 
-void ElevationView3D::convertTrackPointsTo3D(const std::vector<TrackPoint>& points)
-{
-    qDebug() << "ElevationView3D::convertTrackPointsTo3D - Converting" << points.size() << "points";
-    
-    // Pre-allocate memory to avoid reallocations
-    m_trackPositions.reserve(std::min(points.size(), size_t(10000)));
-    
-    // Sample a subset of points if there are too many 
-    const size_t MAX_POINTS_TO_RENDER = 5000; // Limit for very large datasets
-    size_t sampleEvery = (points.size() > MAX_POINTS_TO_RENDER) ? 
-        points.size() / MAX_POINTS_TO_RENDER + 1 : 1;
-        
-    if (sampleEvery > 1) {
-        qDebug() << "ElevationView3D::convertTrackPointsTo3D - Sampling every" << sampleEvery 
-                 << "points due to large dataset";
-    }
-    
-    // Convert points to 3D positions
-    for (size_t i = 0; i < points.size(); i += sampleEvery) {
-        m_trackPositions.push_back(trackPointToVector3D(points[i]));
-    }
-    
-    // Always ensure the last point is included for proper route termination
-    if (!points.empty()) {
-        QVector3D lastPoint = trackPointToVector3D(points.back());
-        if (m_trackPositions.empty() || m_trackPositions.back() != lastPoint) {
-            m_trackPositions.push_back(lastPoint);
-        }
-    }
-    
-    qDebug() << "ElevationView3D::convertTrackPointsTo3D - Processed" << m_trackPositions.size() 
-             << "3D positions";
-}
 
-void ElevationView3D::createSceneEntities()
-{
-    // Only proceed if we have valid track positions
-    if (m_trackPositions.empty()) {
-        qWarning() << "ElevationView3D::createSceneEntities - No track positions available";
-        return;
+    // Enable controls
+    m_playPauseButton->setEnabled(true);
+    m_stopButton->setEnabled(true);
+    m_speedSlider->setEnabled(true);
+    m_markerEntity->setEnabled(true);
+
+    // Reset camera to view the new route and update marker to start
+    resetCameraView();
+    updatePosition(0);
+
+    // 4. Fetch terrain data
+    double minLat = m_trackPoints.front().coord.latitude();
+    double maxLat = m_trackPoints.front().coord.latitude();
+    double minLon = m_trackPoints.front().coord.longitude();
+    double maxLon = m_trackPoints.front().coord.longitude();
+    for (const auto& point : m_trackPoints) {
+        minLat = std::min(minLat, point.coord.latitude());
+        maxLat = std::max(maxLat, point.coord.latitude());
+        minLon = std::min(minLon, point.coord.longitude());
+        maxLon = std::max(maxLon, point.coord.longitude());
     }
-    
-    // Create terrain mesh
-    qDebug() << "ElevationView3D::createSceneEntities - Creating terrain";
-    createTerrain();
-    
-    // Create route visualization
-    qDebug() << "ElevationView3D::createSceneEntities - Creating route";
-    createRoute();
-    
-    // Create position marker
-    qDebug() << "ElevationView3D::createSceneEntities - Creating marker";
-    createMarker();
+    double latBuffer = (maxLat - minLat) * 0.2; // Add a 20% buffer
+    double lonBuffer = (maxLon - minLon) * 0.2;
+    m_terrainService->fetchTerrainData(maxLat + latBuffer, minLat - latBuffer, minLon - lonBuffer, maxLon + lonBuffer, 100, 100);
 }
 
 void ElevationView3D::resetCameraView()
 {
-    if (m_trackPositions.empty() || !m_camera) {
+    if (!m_routeData || m_routeData->getPositions().empty()) {
         return;
     }
-    
-    qDebug() << "ElevationView3D::resetCameraView - Resetting camera position";
-    
-    // Find bounding box of the route
+
+    const auto& positions = m_routeData->getPositions();
     QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
     QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-    
-    for (const auto& pos : m_trackPositions) {
+
+    for (const auto& pos : positions) {
         routeMin.setX(std::min(routeMin.x(), pos.x()));
         routeMin.setY(std::min(routeMin.y(), pos.y()));
         routeMin.setZ(std::min(routeMin.z(), pos.z()));
-        
         routeMax.setX(std::max(routeMax.x(), pos.x()));
         routeMax.setY(std::max(routeMax.y(), pos.y()));
         routeMax.setZ(std::max(routeMax.z(), pos.z()));
     }
-    
-    // Calculate center and size of the route
+
     QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
     float routeSize = (routeMax - routeMin).length();
-    
-    // Position camera to view the entire route
-    m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
-    m_camera->setViewCenter(routeCenter);
-    
-    // Reset animation parameters
-    m_flythroughProgress = 0.0f;
-    m_currentPositionIndex = 0;
-    
-    // Update marker to first position if it exists
-    if (m_markerEntity && !m_trackPositions.empty()) {
-        updateMarkerPosition(0);
-    }
-        
-    qDebug() << "ElevationView3D::setTrackData - Completed successfully";
+    QVector3D cameraPos = routeCenter + QVector3D(0, routeSize * 0.5f, routeSize * 1.2f);
+
+    logDebug("ElevationView3D", QString("Route BBox Min: (%1, %2, %3)").arg(routeMin.x()).arg(routeMin.y()).arg(routeMin.z()));
+    logDebug("ElevationView3D", QString("Route BBox Max: (%1, %2, %3)").arg(routeMax.x()).arg(routeMax.y()).arg(routeMax.z()));
+    logDebug("ElevationView3D", QString("Route Center: (%1, %2, %3)").arg(routeCenter.x()).arg(routeCenter.y()).arg(routeCenter.z()));
+    logDebug("ElevationView3D", QString("Route Size: %1").arg(routeSize));
+    logDebug("ElevationView3D", QString("Setting camera position to: (%1, %2, %3)").arg(cameraPos.x()).arg(cameraPos.y()).arg(cameraPos.z()));
+
+    m_3dWindow->camera()->setPosition(cameraPos);
+    m_3dWindow->camera()->setViewCenter(routeCenter);
 }
 
-void ElevationView3D::createTerrain()
+void ElevationView3D::updatePosition(size_t pointIndex)
 {
-    // This method is now effectively a placeholder.
-    // The terrain is created when the terrain data is ready in onTerrainDataReady.
-    // We could potentially create a placeholder flat terrain here while the real data loads.
-    qDebug() << "ElevationView3D::createTerrain - Deferred to onTerrainDataReady";
-}
-
-void ElevationView3D::createRoute()
-{
-    qDebug() << "ElevationView3D::createRoute - Starting";
-    
-    // Ensure we're not creating route with invalid data
-    if (m_trackPoints.empty()) {
-        qWarning() << "ElevationView3D::createRoute - No track points available";
+    if (!m_routeData || !m_markerEntity) {
         return;
     }
-    
-    try {
-        QElapsedTimer timer;
-        timer.start();
-        
-        m_routeEntity = createOptimizedRoutePath(m_trackPoints);
-        if (m_routeEntity && m_rootEntity) {
-            qDebug() << "ElevationView3D::createRoute - Setting parent to root entity";
-            m_routeEntity->setParent(m_rootEntity);
-        } else {
-            qWarning() << "ElevationView3D::createRoute - Failed to create route path or no root entity";
-            if (m_routeEntity) {
-                m_routeEntity->deleteLater();
-                m_routeEntity = nullptr;
-            }
-        }
-        
-        qDebug() << "ElevationView3D::createRoute - Completed in" << timer.elapsed() << "ms";
-    } catch (const std::exception& e) {
-        qCritical() << "ElevationView3D::createRoute - Exception:" << e.what();
-    } catch (...) {
-        qCritical() << "ElevationView3D::createRoute - Unknown exception";
+
+    const auto& positions = m_routeData->getPositions();
+    if (pointIndex >= positions.size()) {
+        return;
+    }
+
+    // Update marker position
+    if (auto* transform = m_markerEntity->findChild<Qt3DCore::QTransform*>()) {
+        transform->setTranslation(positions[pointIndex]);
     }
 }
 
-void ElevationView3D::createMarker()
+void ElevationView3D::onTerrainDataReady(const TerrainData& data)
 {
-    qDebug() << "ElevationView3D::createMarker - Starting";
-    
-    try {
-        m_markerEntity = createPositionMarker();
-        if (m_markerEntity && m_rootEntity) {
-            qDebug() << "ElevationView3D::createMarker - Setting parent to root entity";
-            m_markerEntity->setParent(m_rootEntity);
-            
-            // Position at start of route
-            if (!m_trackPositions.empty()) {
-                qDebug() << "ElevationView3D::createMarker - Updating marker position";
-                updateMarkerPosition(0);
-            } else {
-                qWarning() << "ElevationView3D::createMarker - No track positions available";
-            }
-        } else {
-            qWarning() << "ElevationView3D::createMarker - Failed to create position marker or no root entity";
-            if (m_markerEntity) {
-                m_markerEntity->deleteLater();
-                m_markerEntity = nullptr;
-            }
-        }
-    } catch (const std::exception& e) {
-        qCritical() << "ElevationView3D::createMarker - Exception:" << e.what();
-    } catch (...) {
-        qCritical() << "ElevationView3D::createMarker - Unknown exception";
-    }
-    
-    qDebug() << "ElevationView3D::createMarker - Completed";
-}
+    logInfo("ElevationView3D", "Received terrain data. Generating mesh...");
 
-Qt3DCore::QEntity* ElevationView3D::createTerrainMesh(const TerrainData& terrainData)
-{
-    qDebug() << "ElevationView3D::createTerrainMesh - Creating mesh from terrain data";
+    // Clean up old terrain entity
+    delete m_terrainEntity;
+    m_terrainEntity = new Qt3DCore::QEntity(m_rootEntity);
 
-    if (terrainData.elevationGrid.empty() || terrainData.elevationGrid[0].empty()) {
-        qWarning() << "ElevationView3D::createTerrainMesh - No elevation data provided, returning nullptr";
-        return nullptr;
+    if (data.elevationGrid.empty() || data.elevationGrid[0].empty()) {
+        logWarning("ElevationView3D", "Terrain data is empty, cannot generate mesh.");
+        return;
     }
 
-    Qt3DCore::QEntity* terrainEntity = new Qt3DCore::QEntity();
-    Qt3DRender::QGeometryRenderer* meshRenderer = new Qt3DRender::QGeometryRenderer();
-    Qt3DRender::QGeometry* geometry = new Qt3DRender::QGeometry(meshRenderer);
-
+    auto* geometry = new Qt3DRender::QGeometry(m_terrainEntity);
     QByteArray vertexBufferData;
-    int gridHeight = terrainData.elevationGrid.size();
-    int gridWidth = terrainData.elevationGrid[0].size();
-    vertexBufferData.resize(gridWidth * gridHeight * (3 + 3 + 2) * sizeof(float));
+    QByteArray indexBufferData;
+
+    const int gridHeight = data.elevationGrid.size();
+    const int gridWidth = data.elevationGrid[0].size();
+    const int numVertices = gridWidth * gridHeight;
+    const int numIndices = (gridWidth - 1) * (gridHeight - 1) * 2 * 3;
+
+    vertexBufferData.resize(numVertices * (3 + 3) * sizeof(float)); // Pos + Normal
     float* p = reinterpret_cast<float*>(vertexBufferData.data());
 
-    // This is a simplified conversion from lat/lon to a flat 3D space.
-    // It is not accurate for large areas but is sufficient for this visualization.
-    const double latToMeters = 111320.0;
-    const double lonToMeters = 40075000.0 * cos(terrainData.topLeft.latitude() * M_PI / 180.0) / 360.0;
+    indexBufferData.resize(numIndices * sizeof(unsigned int));
+    unsigned int* indices = reinterpret_cast<unsigned int*>(indexBufferData.data());
 
-    double widthMeters = (terrainData.bottomRight.longitude() - terrainData.topLeft.longitude()) * lonToMeters;
-    double heightMeters = (terrainData.topLeft.latitude() - terrainData.bottomRight.latitude()) * latToMeters;
+    const double originLon = m_trackPoints.front().coord.longitude();
+    const double originLat = m_trackPoints.front().coord.latitude();
 
-
+    // Generate vertices
     for (int i = 0; i < gridHeight; ++i) {
         for (int j = 0; j < gridWidth; ++j) {
-            // Position
-            float x = (float)(j * widthMeters / (gridWidth - 1));
-            float z = (float)(i * heightMeters / (gridHeight - 1));
-            float y = terrainData.elevationGrid[i][j] * m_elevationScale;
-            *p++ = x;
-            *p++ = y;
-            *p++ = z;
+            double lat = data.topLeft.latitude() - i * (data.topLeft.latitude() - data.bottomRight.latitude()) / (gridHeight - 1);
+            double lon = data.topLeft.longitude() + j * (data.bottomRight.longitude() - data.topLeft.longitude()) / (gridWidth - 1);
 
-            // Normals (temporary, will be properly calculated later)
+            QVector2D mercatorCoords = lonLatToMercator(lon, lat, originLon, originLat);
+            float elevation = data.elevationGrid[i][j] * m_elevationScale;
+
+            *p++ = mercatorCoords.x();
+            *p++ = elevation;
+            *p++ = mercatorCoords.y();
+
+            // Placeholder for normals
             *p++ = 0.0f;
             *p++ = 1.0f;
             *p++ = 0.0f;
-
-            // Texture coordinates
-            *p++ = (float)j / (gridWidth - 1);
-            *p++ = (float)i / (gridHeight - 1);
         }
     }
 
-    QByteArray indexBufferData;
-    indexBufferData.resize((gridWidth - 1) * (gridHeight - 1) * 6 * sizeof(unsigned int));
-    unsigned int* indices = reinterpret_cast<unsigned int*>(indexBufferData.data());
+    // Generate indices
     for (int i = 0; i < gridHeight - 1; ++i) {
         for (int j = 0; j < gridWidth - 1; ++j) {
             unsigned int i0 = i * gridWidth + j;
@@ -715,763 +334,76 @@ Qt3DCore::QEntity* ElevationView3D::createTerrainMesh(const TerrainData& terrain
         }
     }
 
-    Qt3DRender::QBuffer* vertexBuffer = new Qt3DRender::QBuffer(geometry);
+    auto* vertexBuffer = new Qt3DRender::QBuffer(geometry);
     vertexBuffer->setData(vertexBufferData);
-
-    Qt3DRender::QBuffer* indexBuffer = new Qt3DRender::QBuffer(geometry);
+    auto* indexBuffer = new Qt3DRender::QBuffer(geometry);
     indexBuffer->setData(indexBufferData);
 
     // Attributes
-    int stride = (3 + 3 + 2) * sizeof(float);
-    Qt3DRender::QAttribute* posAttr = new Qt3DRender::QAttribute();
+    auto* posAttr = new Qt3DRender::QAttribute(geometry);
     posAttr->setName(Qt3DRender::QAttribute::defaultPositionAttributeName());
-    posAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
-    posAttr->setBuffer(vertexBuffer);
     posAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
     posAttr->setVertexSize(3);
-    posAttr->setByteOffset(0);
-    posAttr->setByteStride(stride);
-    posAttr->setCount(gridWidth * gridHeight);
+    posAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    posAttr->setBuffer(vertexBuffer);
+    posAttr->setByteStride(6 * sizeof(float));
+    posAttr->setCount(numVertices);
+    geometry->addAttribute(posAttr);
 
-    Qt3DRender::QAttribute* normAttr = new Qt3DRender::QAttribute();
+    auto* normAttr = new Qt3DRender::QAttribute(geometry);
     normAttr->setName(Qt3DRender::QAttribute::defaultNormalAttributeName());
-    normAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
-    normAttr->setBuffer(vertexBuffer);
     normAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
     normAttr->setVertexSize(3);
+    normAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    normAttr->setBuffer(vertexBuffer);
     normAttr->setByteOffset(3 * sizeof(float));
-    normAttr->setByteStride(stride);
-    normAttr->setCount(gridWidth * gridHeight);
+    normAttr->setByteStride(6 * sizeof(float));
+    normAttr->setCount(numVertices);
+    geometry->addAttribute(normAttr);
 
-    Qt3DRender::QAttribute* texAttr = new Qt3DRender::QAttribute();
-    texAttr->setName(Qt3DRender::QAttribute::defaultTextureCoordinateAttributeName());
-    texAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
-    texAttr->setBuffer(vertexBuffer);
-    texAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
-    texAttr->setVertexSize(2);
-    texAttr->setByteOffset((3 + 3) * sizeof(float));
-    texAttr->setByteStride(stride);
-    texAttr->setCount(gridWidth * gridHeight);
-
-    Qt3DRender::QAttribute* indexAttr = new Qt3DRender::QAttribute();
+    auto* indexAttr = new Qt3DRender::QAttribute(geometry);
     indexAttr->setAttributeType(Qt3DRender::QAttribute::IndexAttribute);
     indexAttr->setBuffer(indexBuffer);
     indexAttr->setVertexBaseType(Qt3DRender::QAttribute::UnsignedInt);
-    indexAttr->setCount((gridWidth - 1) * (gridHeight - 1) * 6);
-
-    geometry->addAttribute(posAttr);
-    geometry->addAttribute(normAttr);
-    geometry->addAttribute(texAttr);
+    indexAttr->setCount(numIndices);
     geometry->addAttribute(indexAttr);
 
-    meshRenderer->setGeometry(geometry);
-    meshRenderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+    auto* renderer = new Qt3DRender::QGeometryRenderer();
+    renderer->setGeometry(geometry);
+    renderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
 
-    // Material
-    Qt3DExtras::QDiffuseSpecularMaterial* material = new Qt3DExtras::QDiffuseSpecularMaterial();
-    if (!terrainData.satelliteImagePath.isEmpty()) {
-        Qt3DRender::QTexture2D* texture = new Qt3DRender::QTexture2D();
-        Qt3DRender::QTextureImage* textureImage = new Qt3DRender::QTextureImage();
-        textureImage->setSource(QUrl::fromLocalFile(terrainData.satelliteImagePath));
-        texture->addTextureImage(textureImage);
-        material->setDiffuse(QVariant::fromValue(texture));
-        material->setShininess(10.0f);
-    } else {
-        material->setDiffuse(QColor(Qt::darkGray));
-    }
+    auto* material = new Qt3DExtras::QPhongMaterial();
+    material->setDiffuse(QColor(QRgb(0x8B4513))); // SaddleBrown
 
-    terrainEntity->addComponent(meshRenderer);
-    terrainEntity->addComponent(material);
-    terrainEntity->addComponent(new Qt3DCore::QTransform());
-
-    return terrainEntity;
-}
-
-Qt3DCore::QEntity* ElevationView3D::createOptimizedRoutePath(const std::vector<TrackPoint>& points)
-{
-    if (points.size() < 2) {
-        return nullptr;
-    }
-    
-    // Create the root route entity
-    Qt3DCore::QEntity* routeEntity = new Qt3DCore::QEntity();
-    
-    // Simplify the route if it's too detailed
-    std::vector<TrackPoint> simplifiedPoints;
-    simplifyRoute(points, simplifiedPoints, MAX_ROUTE_VERTICES);
-    
-    // Group segments into batches for better performance
-    size_t currentBatch = 0;
-    size_t totalBatches = (simplifiedPoints.size() / ROUTE_SEGMENT_BATCH_SIZE) + 1;
-    
-    while (currentBatch < totalBatches) {
-        // Create custom mesh entity for this batch
-        size_t startIdx = currentBatch * ROUTE_SEGMENT_BATCH_SIZE;
-        size_t endIdx = std::min(startIdx + ROUTE_SEGMENT_BATCH_SIZE, simplifiedPoints.size() - 1);
-        
-        // Skip if we don't have enough points for this batch
-        if (startIdx >= simplifiedPoints.size() - 1) {
-            break;
-        }
-        
-        // Create a batch entity
-        createBatchedSegments(routeEntity, simplifiedPoints, startIdx, endIdx);
-        currentBatch++;
-    }
-    
-    return routeEntity;
-}
-
-void ElevationView3D::createBatchedSegments(Qt3DCore::QEntity* parentEntity, 
-                                          const std::vector<TrackPoint>& points,
-                                          size_t startIdx, size_t endIdx)
-{
-    qDebug() << "ElevationView3D::createBatchedSegments - Starting for indices" 
-             << startIdx << "to" << endIdx << "(total points:" << points.size() << ")";
-    
-    if (startIdx >= points.size() - 1 || endIdx >= points.size()) {
-        qWarning() << "ElevationView3D::createBatchedSegments - Invalid indices, returning";
-        return;
-    }
-    
-    // Create entity for this batch
-    Qt3DCore::QEntity* batchEntity = new Qt3DCore::QEntity(parentEntity);
-    
-    // Create a custom mesh for better performance
-    Qt3DRender::QGeometry* geometry = new Qt3DRender::QGeometry(batchEntity);
-    
-    // Create buffers with correct UsageType enum values
-    Qt3DRender::QBuffer* positionBuffer = new Qt3DRender::QBuffer(geometry);
-    positionBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw); // Changed from VertexBuffer to StaticDraw
-    
-    Qt3DRender::QBuffer* indexBuffer = new Qt3DRender::QBuffer(geometry);
-    indexBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw);  // Changed from IndexBuffer to StaticDraw
-    
-    Qt3DRender::QBuffer* colorBuffer = new Qt3DRender::QBuffer(geometry);
-    colorBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw);  // Changed from VertexBuffer to StaticDraw
-    
-    // Calculate average color and gradient for this batch
-    QVector<QVector3D> positions;
-    QVector<QVector3D> colors;
-    QVector<uint> indices;
-    
-    const float lineRadius = 0.4f; // Thinner lines for better performance
-    int segmentResolution = 6; // Lower resolution for better performance
-    
-    // Generate a cylinder-like geometry for each segment
-    for (size_t i = startIdx; i < endIdx; i++) {
-        // Calculate segment properties
-        QVector3D start = trackPointToVector3D(points[i]);
-        QVector3D end = trackPointToVector3D(points[i + 1]);
-        
-        // Calculate segment color based on gradient
-        float gradient = 0.0f;
-        if (i < points.size() - 1) {
-            float elevDiff = points[i + 1].elevation - points[i].elevation;
-            float distance = points[i + 1].distance - points[i].distance;
-            if (distance > 0) {
-                gradient = (elevDiff / distance) * 100.0f;
-            }
-        }
-        
-        // Choose color based on gradient
-        QVector3D segmentColor;
-        if (gradient > 10.0f) {
-            segmentColor = QVector3D(1.0f, 0.0f, 0.0f); // Steep climb - red
-        } else if (gradient > 5.0f) {
-            segmentColor = QVector3D(1.0f, 0.65f, 0.0f); // Moderate climb - orange
-        } else if (gradient > 2.0f) {
-            segmentColor = QVector3D(1.0f, 1.0f, 0.0f); // Mild climb - yellow
-        } else if (gradient < -10.0f) {
-            segmentColor = QVector3D(0.5f, 0.0f, 0.5f); // Steep descent - purple
-        } else if (gradient < -5.0f) {
-            segmentColor = QVector3D(0.0f, 0.0f, 1.0f); // Moderate descent - blue
-        } else if (gradient < -2.0f) {
-            segmentColor = QVector3D(0.4f, 0.7f, 1.0f); // Mild descent - light blue
-        } else {
-            segmentColor = QVector3D(0.0f, 0.5f, 0.0f); // Flat - green
-        }
-        
-        // Calculate segment direction
-        QVector3D direction = end - start;
-        direction.normalize();
-        
-        // Define cylinder vertices around the segment
-        QVector3D right, up;
-        
-        // Find perpendicular vectors to create a cylinder
-        if (qAbs(direction.y()) > 0.99f) {
-            right = QVector3D(1.0f, 0.0f, 0.0f); // Handle vertical segments
-        } else {
-            right = QVector3D::crossProduct(direction, QVector3D(0.0f, 1.0f, 0.0f)).normalized();
-        }
-        up = QVector3D::crossProduct(right, direction).normalized();
-        
-        // Starting index for this segment
-        uint baseIndex = positions.size();
-        
-        // Generate a simpler tube for the segment
-        for (int j = 0; j < segmentResolution; j++) {
-            float angle = j * 2.0f * M_PI / segmentResolution;
-            float x = ::cos(angle);
-            float y = ::sin(angle);
-            
-            // Add vertex at the start cap
-            QVector3D offset = right * x * lineRadius + up * y * lineRadius;
-            positions.append(start + offset);
-            colors.append(segmentColor);
-            
-            // Add vertex at the end cap
-            positions.append(end + offset);
-            colors.append(segmentColor);
-            
-            // Add indices for triangles (2 triangles per side of cylinder)
-            uint nextJ = (j + 1) % segmentResolution;
-            uint curr1 = baseIndex + j * 2;
-            uint curr2 = baseIndex + j * 2 + 1;
-            uint next1 = baseIndex + nextJ * 2;
-            uint next2 = baseIndex + nextJ * 2 + 1;
-            
-            // First triangle
-            indices.append(curr1);
-            indices.append(next1);
-            indices.append(curr2);
-            
-            // Second triangle
-            indices.append(curr2);
-            indices.append(next1);
-            indices.append(next2);
-        }
-    }
-    
-    // Set buffer data
-    QByteArray positionData(reinterpret_cast<const char*>(positions.constData()), 
-                          positions.size() * 3 * sizeof(float));
-    positionBuffer->setData(positionData);
-    
-    QByteArray colorData(reinterpret_cast<const char*>(colors.constData()),
-                       colors.size() * 3 * sizeof(float));
-    colorBuffer->setData(colorData);
-    
-    QByteArray indexData(reinterpret_cast<const char*>(indices.constData()),
-                       indices.size() * sizeof(uint));
-    indexBuffer->setData(indexData);
-    
-    // Add attributes to the geometry
-    Qt3DRender::QAttribute* positionAttribute = new Qt3DRender::QAttribute(geometry);
-    positionAttribute->setName(Qt3DRender::QAttribute::defaultPositionAttributeName());
-    positionAttribute->setVertexBaseType(Qt3DRender::QAttribute::Float);
-    positionAttribute->setVertexSize(3);
-    positionAttribute->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
-    positionAttribute->setBuffer(positionBuffer);
-    positionAttribute->setByteOffset(0);
-    positionAttribute->setByteStride(3 * sizeof(float));
-    positionAttribute->setCount(positions.size());
-    geometry->addAttribute(positionAttribute);
-    
-    Qt3DRender::QAttribute* colorAttribute = new Qt3DRender::QAttribute(geometry);
-    colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
-    colorAttribute->setVertexBaseType(Qt3DRender::QAttribute::Float);
-    colorAttribute->setVertexSize(3);
-    colorAttribute->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
-    colorAttribute->setBuffer(colorBuffer);
-    colorAttribute->setByteOffset(0);
-    colorAttribute->setByteStride(3 * sizeof(float));
-    colorAttribute->setCount(colors.size());
-    geometry->addAttribute(colorAttribute);
-    
-    Qt3DRender::QAttribute* indexAttribute = new Qt3DRender::QAttribute(geometry);
-    indexAttribute->setAttributeType(Qt3DRender::QAttribute::IndexAttribute);
-    indexAttribute->setVertexBaseType(Qt3DRender::QAttribute::UnsignedInt);
-    indexAttribute->setBuffer(indexBuffer);
-    indexAttribute->setCount(indices.size());
-    geometry->addAttribute(indexAttribute);
-    
-    // Create a geometry renderer
-    Qt3DRender::QGeometryRenderer* mesh = new Qt3DRender::QGeometryRenderer();
-    mesh->setGeometry(geometry);
-    mesh->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
-    
-    // Create material - use faster PhongAlphaMaterial
-    Qt3DExtras::QPhongAlphaMaterial* material = new Qt3DExtras::QPhongAlphaMaterial();
-    material->setAmbient(QColor(50, 50, 50));
-    material->setDiffuse(QColor(180, 180, 180)); // Will be modulated by vertex colors
-    material->setSpecular(QColor(80, 80, 80));
-    material->setShininess(20.0f);
-    material->setAlpha(1.0f);
-    
-    // Add components to entity
-    batchEntity->addComponent(mesh);
-    batchEntity->addComponent(material);
-}
-
-// New helper method to simplify route points for better performance
-void ElevationView3D::simplifyRoute(const std::vector<TrackPoint>& input, 
-                                  std::vector<TrackPoint>& output, 
-                                  int maxPoints)
-{
-    qDebug() << "ElevationView3D::simplifyRoute - Starting with" << input.size() 
-             << "points, max output =" << maxPoints;
-    
-    output.clear(); // Make sure output is empty before starting
-    
-    if (input.empty()) {
-        qWarning() << "ElevationView3D::simplifyRoute - No input points, returning early";
-        return; // Return early if there's no input
-    }
-    
-    try {
-        if (static_cast<size_t>(maxPoints) >= input.size()) {
-            // No simplification needed
-            qDebug() << "ElevationView3D::simplifyRoute - No simplification needed, copying all points";
-            output = input;
-            return;
-        }
-        
-        // Calculate how many points to keep
-        int keepEveryNth = std::max(1, static_cast<int>(input.size() / maxPoints));
-        qDebug() << "ElevationView3D::simplifyRoute - Will keep every" << keepEveryNth << "point";
-        
-        // Allocate enough space upfront to avoid reallocations
-        output.reserve(maxPoints + 2);
-        
-        // Start with the first point
-        output.push_back(input.front());
-        
-        // Add the subset of points
-        for (size_t i = 1; i < input.size() - 1; i += keepEveryNth) {
-            output.push_back(input[i]);
-        }
-        
-        // Always add the last point if not already added
-        if (output.size() == 1 || output.back().coord != input.back().coord) {
-            output.push_back(input.back());
-        }
-        
-        qDebug() << "ElevationView3D::simplifyRoute - Route simplified from" << input.size() 
-                 << "to" << output.size() << "points";
-    } catch (const std::exception& e) {
-        qCritical() << "ElevationView3D::simplifyRoute - Exception:" << e.what();
-    } catch (...) {
-        qCritical() << "ElevationView3D::simplifyRoute - Unknown exception occurred";
-    }
-}
-
-Qt3DCore::QEntity* ElevationView3D::createPositionMarker()
-{
-    // Create a sphere to represent the current position
-    Qt3DCore::QEntity* markerEntity = new Qt3DCore::QEntity();
-    
-    // Create mesh
-    Qt3DExtras::QSphereMesh* markerMesh = new Qt3DExtras::QSphereMesh();
-    markerMesh->setRadius(MARKER_SIZE);
-    markerMesh->setRings(16);
-    markerMesh->setSlices(16);
-    
-    // Create material
-    Qt3DExtras::QDiffuseSpecularMaterial* markerMaterial = new Qt3DExtras::QDiffuseSpecularMaterial();
-    markerMaterial->setDiffuse(QColor(255, 0, 0));
-    markerMaterial->setSpecular(QColor(255, 255, 255));
-    markerMaterial->setShininess(50.0f);
-    
-    // Create transform
-    Qt3DCore::QTransform* markerTransform = new Qt3DCore::QTransform();
-    
-    // Add components
-    markerEntity->addComponent(markerMesh);
-    markerEntity->addComponent(markerMaterial);
-    markerEntity->addComponent(markerTransform);
-    
-    return markerEntity;
-}
-
-void ElevationView3D::updateMarkerPosition(size_t pointIndex)
-{
-    qDebug() << "ElevationView3D::updateMarkerPosition - Updating to index" << pointIndex
-             << "(total positions:" << m_trackPositions.size() << ")";
-    
-    if (pointIndex >= m_trackPositions.size() || !m_markerEntity) {
-        qWarning() << "ElevationView3D::updateMarkerPosition - Invalid index or no marker entity, returning";
-        return;
-    }
-    
-    m_currentPositionIndex = pointIndex;
-    
-    // Update marker position
-    Qt3DCore::QTransform* markerTransform = m_markerEntity->findChild<Qt3DCore::QTransform*>();
-    if (markerTransform) {
-        markerTransform->setTranslation(m_trackPositions[pointIndex]);
-    } else {
-        qWarning() << "ElevationView3D::updateMarkerPosition - No transform component found on marker";
-    }
-}
-
-void ElevationView3D::updatePosition(size_t pointIndex)
-{
-    if (pointIndex >= m_trackPositions.size()) {
-        return;
-    }
-    
-    // Update marker
-    updateMarkerPosition(pointIndex);
-    
-    // If in first-person mode, update camera position
-    if (m_firstPersonMode && !m_flythroughActive) {
-        // Get current position
-        QVector3D currentPos = m_trackPositions[pointIndex];
-        
-        // Calculate look direction
-        QVector3D lookDir;
-        if (pointIndex < m_trackPositions.size() - 1) {
-            lookDir = (m_trackPositions[pointIndex + 1] - currentPos).normalized();
-        } else if (pointIndex > 0) {
-            lookDir = (currentPos - m_trackPositions[pointIndex - 1]).normalized();
-        } else {
-            lookDir = QVector3D(1, 0, 0); // Default look direction
-        }
-        
-        // Apply camera tilt
-        QVector3D upVector(0, 1, 0);
-        QQuaternion tiltRotation = QQuaternion::fromAxisAndAngle(
-            QVector3D::crossProduct(lookDir, upVector).normalized(), 
-            -m_cameraTilt
-        );
-        lookDir = tiltRotation.rotatedVector(lookDir);
-        
-        // Set camera position slightly above the track
-        QVector3D cameraPos = currentPos + QVector3D(0, 1.5f, 0);
-        QVector3D lookTarget = cameraPos + lookDir * 10.0f;
-        
-        // Update camera
-        m_camera->setPosition(cameraPos);
-        m_camera->setViewCenter(lookTarget);
-    }
-}
-
-void ElevationView3D::startFlythrough()
-{
-    if (m_trackPositions.empty()) {
-        return;
-    }
-    
-    // Start animation
-    m_flythroughActive = true;
-    m_flythroughTimer->start();
-    
-    // Switch to first-person mode
-    m_firstPersonMode = true;
-    setupCamera();
-    
-    // Set camera to starting position
-    m_flythroughProgress = 0.0f;
-    updateFlythrough();
-}
-
-void ElevationView3D::pauseFlythrough()
-{
-    m_flythroughActive = !m_flythroughActive;
-    
-    if (m_flythroughActive) {
-        m_flythroughTimer->start();
-    } else {
-        m_flythroughTimer->stop();
-    }
-}
-
-void ElevationView3D::stopFlythrough()
-{
-    // Stop the animation
-    m_flythroughActive = false;
-    m_flythroughTimer->stop();
-    m_flythroughProgress = 0.0f;
-    
-    // Reset camera to overview mode
-    m_firstPersonMode = false;
-    setupCamera();
-    
-    // Reset marker to start
-    updateMarkerPosition(0);
-    
-    // Reset camera to view the entire route
-    if (!m_trackPositions.empty()) {
-        // Find center of route
-        QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
-        QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-        
-        for (const auto& pos : m_trackPositions) {
-            routeMin.setX(std::min(routeMin.x(), pos.x()));
-            routeMin.setY(std::min(routeMin.y(), pos.y()));
-            routeMin.setZ(std::min(routeMin.z(), pos.z()));
-            
-            routeMax.setX(std::max(routeMax.x(), pos.x()));
-            routeMax.setY(std::max(routeMax.y(), pos.y()));
-            routeMax.setZ(std::max(routeMax.z(), pos.z()));
-        }
-        
-        QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
-        float routeSize = (routeMax - routeMin).length();
-        
-        // Position camera to view the entire route
-        m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
-        m_camera->setViewCenter(routeCenter);
-    }
-    
-    // Emit position changed signal for the first point
-    emit positionChanged(0);
-}
-
-void ElevationView3D::toggleCameraMode()
-{
-    m_firstPersonMode = !m_firstPersonMode;
-    setupCamera();
-    
-    if (m_firstPersonMode) {
-        // In first-person mode, move camera to current position
-        updatePosition(m_currentPositionIndex);
-    } else {
-        // In overview mode, show entire route
-        if (!m_trackPositions.empty()) {
-            // Find center of route
-            QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
-            QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-            
-            for (const auto& pos : m_trackPositions) {
-                routeMin.setX(std::min(routeMin.x(), pos.x()));
-                routeMin.setY(std::min(routeMin.y(), pos.y()));
-                routeMin.setZ(std::min(routeMin.z(), pos.z()));
-                
-                routeMax.setX(std::max(routeMax.x(), pos.x()));
-                routeMax.setY(std::max(routeMax.y(), pos.y()));
-                routeMax.setZ(std::max(routeMax.z(), pos.z()));
-            }
-            
-            QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
-            float routeSize = (routeMax - routeMin).length();
-            
-            // Position camera to view the entire route
-            m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
-            m_camera->setViewCenter(routeCenter);
-        }
-    }
+    m_terrainEntity->addComponent(renderer);
+    m_terrainEntity->addComponent(material);
 }
 
 void ElevationView3D::setElevationScale(float scale)
 {
+    logInfo("ElevationView3D", QString("Setting elevation scale to %1x").arg(scale));
     if (qFuzzyCompare(m_elevationScale, scale)) {
         return;
     }
-    
-    // Store new scale
+
     m_elevationScale = scale;
-    
-    // Regenerate the visualization with the new scale
+
+    // Trigger a full rebuild of the scene with the new scale
     if (!m_trackPoints.empty()) {
         setTrackData(m_trackPoints);
     }
 }
 
-void ElevationView3D::setCameraTilt(float angle)
+void ElevationView3D::onPlayPause(bool checked)
 {
-    m_cameraTilt = angle;
-    
-    // Update camera view if in first person mode
-    if (m_firstPersonMode && !m_flythroughActive) {
-        updatePosition(m_currentPositionIndex);
-    }
-}
-
-void ElevationView3D::updateFlythrough()
-{
-    if (!m_flythroughActive || m_trackPositions.size() < 2) {
-        return;
-    }
-    
-    // Limit updates if we're running slowly
-    qint64 now = QDateTime::currentMSecsSinceEpoch();
-    if (now - m_lastUpdateTime < DEFAULT_FLYTHROUGH_INTERVAL) {
-        return; // Skip this update to maintain performance
-    }
-    m_lastUpdateTime = now;
-    
-    // Increment progress along the route
-    m_flythroughProgress += m_flythroughSpeed;
-    
-    // Check if we've completed the route
-    if (m_flythroughProgress >= 1.0f) {
-        stopFlythrough();
-        return;
-    }
-    
-    // Find current position in the route
-    size_t pointIndex = findClosestPointOnRoute(m_flythroughProgress);
-    
-    // Update marker to current position
-    updateMarkerPosition(pointIndex);
-    
-    // Emit position changed signal
-    emit positionChanged(static_cast<int>(pointIndex));
-    
-    // Calculate camera position
-    QVector3D currentPos = m_trackPositions[pointIndex];
-    
-    // Calculate look direction (toward next point)
-    QVector3D lookDir;
-    if (pointIndex < m_trackPositions.size() - 1) {
-        lookDir = (m_trackPositions[pointIndex + 1] - currentPos).normalized();
+    if (checked) {
+        // Play
+        m_orbitController->setEnabled(false);
+        m_flythroughController->start();
+        m_playPauseButton->setIcon(style()->standardIcon(QStyle::SP_MediaPause));
     } else {
-        lookDir = (currentPos - m_trackPositions[pointIndex - 1]).normalized();
-    }
-    
-    // Apply camera tilt
-    QVector3D upVector(0, 1, 0);
-    QQuaternion tiltRotation = QQuaternion::fromAxisAndAngle(
-        QVector3D::crossProduct(lookDir, upVector).normalized(), 
-        -m_cameraTilt
-    );
-    lookDir = tiltRotation.rotatedVector(lookDir);
-    
-    // Set camera position slightly above the track
-    QVector3D cameraPos = currentPos + QVector3D(0, 1.5f, 0);
-    QVector3D lookTarget = cameraPos + lookDir * 10.0f;
-    
-    // Update camera
-    m_camera->setPosition(cameraPos);
-    m_camera->setViewCenter(lookTarget);
-}
-
-size_t ElevationView3D::findClosestPointOnRoute(float progress)
-{
-    if (m_trackPositions.empty()) {
-        return 0;
-    }
-    
-    // Calculate total route length
-    float totalLength = 0.0f;
-    std::vector<float> cumulativeDistances;
-    cumulativeDistances.push_back(0.0f);
-    
-    for (size_t i = 1; i < m_trackPositions.size(); i++) {
-        float segmentLength = (m_trackPositions[i] - m_trackPositions[i-1]).length();
-        totalLength += segmentLength;
-        cumulativeDistances.push_back(totalLength);
-    }
-    
-    // Normalize to 0.0 - 1.0
-    for (auto& dist : cumulativeDistances) {
-        dist /= totalLength;
-    }
-    
-    // Find the segment containing the target progress
-    float targetDist = progress;
-    
-    for (size_t i = 0; i < cumulativeDistances.size() - 1; i++) {
-        if (targetDist >= cumulativeDistances[i] && targetDist <= cumulativeDistances[i+1]) {
-            // The target is between i and i+1
-            return i;
-        }
-    }
-    
-    // If we get here, we're at the end of the route
-    return m_trackPositions.size() - 1;
-}
-
-void ElevationView3D::updateAnimationSpeed()
-{
-    // No need to adjust timer interval, the speed is controlled by progress increment
-}
-
-QVector3D ElevationView3D::trackPointToVector3D(const TrackPoint& point, bool scaleElevation)
-{
-    // For visualization purpose, convert GPS coordinates to a local 3D space
-    static double originLat = 0.0;
-    static double originLon = 0.0;
-    
-    // Set origin to the first point in the track if not yet set
-    if (qFuzzyIsNull(originLat) && qFuzzyIsNull(originLon) && !m_trackPoints.empty()) {
-        originLat = m_trackPoints[0].coord.latitude();
-        originLon = m_trackPoints[0].coord.longitude();
-        qDebug() << "ElevationView3D::trackPointToVector3D - Set origin to" 
-                 << originLat << "," << originLon;
-    }
-    
-    // Scale factor to convert degrees to a reasonable distance in 3D space
-    // Using an approximate conversion (111.32 km per degree latitude)
-    const double scale = 111320.0 / 10.0; // Scale down by a factor of 10
-    
-    // Calculate X (east-west) component - use cos from cmath directly
-    double x = (point.coord.longitude() - originLon) * scale * ::cos(originLat * M_PI / 180.0);
-    
-    // Calculate Z (north-south) component
-    double z = (point.coord.latitude() - originLat) * scale;
-    
-    // Y is elevation
-    double y = point.elevation;
-    if (scaleElevation) {
-        y *= m_elevationScale;
-    }
-    
-    QVector3D result(x, y, z);
-    // Only log occasionally to avoid flooding the console
-    // Fix: Replace deprecated qrand() with QRandomGenerator
-    if (QRandomGenerator::global()->bounded(1000) == 0) {
-        qDebug() << "ElevationView3D::trackPointToVector3D - Converted" 
-                 << point.coord.latitude() << "," << point.coord.longitude() 
-                 << "," << point.elevation << "to" << result;
-    }
-    
-    return result;
-}
-
-void ElevationView3D::setCameraPosition(const QVector3D& position, const QVector3D& target)
-{
-    m_camera->setPosition(position);
-    m_camera->setViewCenter(target);
-}
-
-void ElevationView3D::updateFPS()
-{
-    // Calculate frames per second
-    qint64 elapsed = m_frameCounter.elapsed();
-    m_fps = m_frameCount * 1000.0 / elapsed;
-    m_frameCount = 0;
-    m_frameCounter.restart();
-    
-    // Update debug info
-    if (m_showDebugInfo) {
-        QString debugText = QString("FPS: %1\n").arg(m_fps, 0, 'f', 1);
-        debugText += QString("Points: %1\n").arg(m_trackPositions.size());
-        debugText += QString("Elev. Scale: %1x\n").arg(m_elevationScale);
-        debugText += QString("Camera Mode: %1\n").arg(m_firstPersonMode ? "First-Person" : "Orbit");
-        debugText += QString("Animation: %1\n").arg(m_flythroughActive ? "Active" : "Stopped");
-        
-        m_debugInfoLabel->setText(debugText);
-    }
-}
-
-// Called by Qt3D when a frame is rendered
-bool ElevationView3D::event(QEvent* event)
-{
-    // Count frames for FPS calculation
-    if (event->type() == QEvent::UpdateRequest) {
-        m_frameCount++;
-    }
-    
-    return QWidget::event(event);
-}
-
-void ElevationView3D::onTerrainDataReady(const TerrainData& data)
-{
-    logInfo("ElevationView3D", "Terrain data ready. Regenerating terrain mesh.");
-
-    // Safely clean up the old terrain entity
-    if (m_terrainEntity) {
-        m_terrainEntity->deleteLater();
-        m_terrainEntity = nullptr;
-    }
-
-    // Create the new terrain entity with the new data
-    m_terrainEntity = createTerrainMesh(data);
-    if (m_terrainEntity && m_rootEntity) {
-        m_terrainEntity->setParent(m_rootEntity);
+        // Pause
+        m_flythroughController->pause();
+        m_playPauseButton->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
     }
 }

--- a/src/ElevationView3D_old.cpp
+++ b/src/ElevationView3D_old.cpp
@@ -1,0 +1,1477 @@
+#include "ElevationView3D.h"
+#include "logging.h"
+#include "TerrainService.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QSlider>
+#include <QLabel>
+#include <QGroupBox>
+#include <QStyle>
+#include <QDebug>
+#include <Qt3DExtras/QDiffuseSpecularMaterial>
+#include <Qt3DRender/QTexture>
+#include <Qt3DExtras/QPhongAlphaMaterial>
+#include <Qt3DExtras/QOrbitCameraController>
+#include <Qt3DExtras/QFirstPersonCameraController>
+#include <Qt3DRender/QPointLight>
+#include <Qt3DRender/QRenderSettings>
+#include <Qt3DExtras/QCuboidMesh>
+#include <Qt3DCore/QTransform>
+#include <Qt3DExtras/QExtrudedTextMesh>
+#include <QCoreApplication>
+#include <cmath>
+#include <algorithm>
+#include <limits>
+#include <QElapsedTimer>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DRender/QGeometry>
+#include <Qt3DRender/QGeometryRenderer>
+#include <QRandomGenerator>
+
+// Constants for 3D visualization with optimization settings
+namespace {
+    const float DEFAULT_ELEVATION_SCALE = 2.0f;
+    const float TERRAIN_WIDTH = 1000.0f;
+    const float MARKER_SIZE = 2.0f;
+    const float DEFAULT_CAMERA_TILT = 30.0f;
+    const int DEFAULT_FLYTHROUGH_INTERVAL = 50; // milliseconds
+    const float DEFAULT_FLYTHROUGH_SPEED = 0.0015f; // progress per update
+
+    // Performance optimization parameters
+    const int ROUTE_SEGMENT_BATCH_SIZE = 25; // Batch this many segments into a single mesh
+    const int MAX_ROUTE_VERTICES = 5000; // Maximum number of vertices for route
+    const int LOD_DISTANCE_THRESHOLD = 200; // Use lower detail for segments farther than this
+    const int FPS_UPDATE_INTERVAL = 1000; // Update FPS display every second
+    const bool ENABLE_CULLING = true; // Enable culling of segments outside view frustum
+
+    #ifndef M_PI
+    const double M_PI = 3.14159265358979323846;
+    #endif
+}
+
+ElevationView3D::ElevationView3D(QWidget* parent)
+    : QWidget(parent),
+      m_currentPositionIndex(0),
+      m_flythroughActive(false),
+      m_flythroughSpeed(DEFAULT_FLYTHROUGH_SPEED),
+      m_flythroughProgress(0.0f),
+      m_animSegment(0),
+      m_firstPersonMode(false),
+      m_elevationScale(DEFAULT_ELEVATION_SCALE),
+      m_cameraTilt(DEFAULT_CAMERA_TILT),
+      m_frameCount(0),
+      m_fps(0),
+      m_showDebugInfo(false),
+      m_lastUpdateTime(0)
+{
+    setupUI();
+
+    // Initialize terrain service
+    m_terrainService = new TerrainService(this);
+    connect(m_terrainService, &TerrainService::terrainDataReady, this, &ElevationView3D::onTerrainDataReady);
+    connect(m_terrainService, &TerrainService::error, [](const QString& errorMessage) {
+        logWarning("TerrainService", errorMessage);
+    });
+
+    // Initialize animation timer
+    m_flythroughTimer = new QTimer(this);
+    m_flythroughTimer->setInterval(DEFAULT_FLYTHROUGH_INTERVAL);
+    connect(m_flythroughTimer, &QTimer::timeout, this, &ElevationView3D::updateFlythrough);
+
+    // Initialize FPS timer
+    m_fpsTimer = new QTimer(this);
+    m_fpsTimer->setInterval(FPS_UPDATE_INTERVAL);
+    connect(m_fpsTimer, &QTimer::timeout, this, &ElevationView3D::updateFPS);
+    m_fpsTimer->start();
+
+    // Performance monitoring
+    m_frameCounter.start();
+}
+
+ElevationView3D::~ElevationView3D()
+{
+    // Clean up is handled automatically through Qt parent/child relationships
+}
+
+void ElevationView3D::setupUI()
+{
+    // Create main layout
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    // Create 3D window
+    m_3dWindow = new Qt3DExtras::Qt3DWindow();
+    m_3dWindow->defaultFrameGraph()->setClearColor(QColor(210, 230, 255));
+
+    // Create root entity
+    m_rootEntity = new Qt3DCore::QEntity();
+
+    // Create camera
+    m_camera = m_3dWindow->camera();
+    m_camera->lens()->setPerspectiveProjection(45.0f, 16.0f/9.0f, 0.1f, 1000.0f);
+    m_camera->setPosition(QVector3D(0, 80, 80));
+    m_camera->setViewCenter(QVector3D(0, 0, 0));
+    m_camera->setUpVector(QVector3D(0, 1, 0));
+
+    // Add camera controller
+    setupCamera();
+
+    // Add global light
+    Qt3DCore::QEntity* lightEntity = new Qt3DCore::QEntity(m_rootEntity);
+    Qt3DRender::QPointLight* light = new Qt3DRender::QPointLight(lightEntity);
+    light->setColor(QColor(255, 255, 255));
+    light->setIntensity(1.0f);
+    lightEntity->addComponent(light);
+
+    Qt3DCore::QTransform* lightTransform = new Qt3DCore::QTransform(lightEntity);
+    lightTransform->setTranslation(QVector3D(0, 150, 0));
+    lightEntity->addComponent(lightTransform);
+
+    // Set root entity
+    m_3dWindow->setRootEntity(m_rootEntity);
+
+    // Create container widget for 3D window
+    QWidget* container = QWidget::createWindowContainer(m_3dWindow);
+    container->setMinimumSize(640, 480);
+    container->setFocusPolicy(Qt::StrongFocus);
+    mainLayout->addWidget(container, 1);
+
+    // Create control panel
+    QGroupBox* controlPanel = new QGroupBox("3D Controls", this);
+    QVBoxLayout* controlLayout = new QVBoxLayout(controlPanel);
+    controlLayout->setContentsMargins(8, 8, 8, 8);
+    controlLayout->setSpacing(4);
+
+    // Create camera controls
+    QHBoxLayout* cameraLayout = new QHBoxLayout();
+    QPushButton* cameraToggleButton = new QPushButton("Toggle Camera Mode", this);
+    connect(cameraToggleButton, &QPushButton::clicked, this, &ElevationView3D::toggleCameraMode);
+    cameraLayout->addWidget(cameraToggleButton);
+
+    // Elevation scale control
+    QLabel* scaleLabel = new QLabel("Elevation Scale:", this);
+    QSlider* scaleSlider = new QSlider(Qt::Horizontal, this);
+    scaleSlider->setRange(10, 50);
+    scaleSlider->setValue(m_elevationScale * 10);
+    scaleSlider->setTickPosition(QSlider::TicksBelow);
+    connect(scaleSlider, &QSlider::valueChanged, [this](int value) {
+        setElevationScale(value / 10.0f);
+    });
+    cameraLayout->addWidget(scaleLabel);
+    cameraLayout->addWidget(scaleSlider, 1);
+
+    controlLayout->addLayout(cameraLayout);
+
+    // Create flythrough controls
+    QHBoxLayout* flythroughLayout = new QHBoxLayout();
+
+    QPushButton* startButton = new QPushButton(this);
+    startButton->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+    startButton->setToolTip("Start Flythrough");
+    connect(startButton, &QPushButton::clicked, this, &ElevationView3D::startFlythrough);
+    flythroughLayout->addWidget(startButton);
+
+    QPushButton* pauseButton = new QPushButton(this);
+    pauseButton->setIcon(style()->standardIcon(QStyle::SP_MediaPause));
+    pauseButton->setToolTip("Pause Flythrough");
+    connect(pauseButton, &QPushButton::clicked, this, &ElevationView3D::pauseFlythrough);
+    flythroughLayout->addWidget(pauseButton);
+
+    QPushButton* stopButton = new QPushButton(this);
+    stopButton->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
+    stopButton->setToolTip("Stop Flythrough");
+    connect(stopButton, &QPushButton::clicked, this, &ElevationView3D::stopFlythrough);
+    flythroughLayout->addWidget(stopButton);
+
+    // Speed control
+    QLabel* speedLabel = new QLabel("Speed:", this);
+    QSlider* speedSlider = new QSlider(Qt::Horizontal, this);
+    speedSlider->setRange(1, 10);
+    speedSlider->setValue(5);
+    speedSlider->setTickPosition(QSlider::TicksBelow);
+    connect(speedSlider, &QSlider::valueChanged, [this](int value) {
+        m_flythroughSpeed = DEFAULT_FLYTHROUGH_SPEED * (value / 5.0f);
+        updateAnimationSpeed();
+    });
+
+    flythroughLayout->addWidget(speedLabel);
+    flythroughLayout->addWidget(speedSlider, 1);
+
+    controlLayout->addLayout(flythroughLayout);
+
+    // Camera tilt control (for first-person mode)
+    QHBoxLayout* tiltLayout = new QHBoxLayout();
+    QLabel* tiltLabel = new QLabel("Camera Tilt:", this);
+    QSlider* tiltSlider = new QSlider(Qt::Horizontal, this);
+    tiltSlider->setRange(0, 90);
+    tiltSlider->setValue(m_cameraTilt);
+    tiltSlider->setTickPosition(QSlider::TicksBelow);
+    connect(tiltSlider, &QSlider::valueChanged, [this](int value) {
+        setCameraTilt(value);
+    });
+
+    tiltLayout->addWidget(tiltLabel);
+    tiltLayout->addWidget(tiltSlider, 1);
+
+    controlLayout->addLayout(tiltLayout);
+
+    // Add debug info label
+    m_debugInfoLabel = new QLabel(this);
+    m_debugInfoLabel->setStyleSheet("background-color: rgba(0,0,0,120); color: white; padding: 4px; font-family: monospace;");
+    m_debugInfoLabel->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    m_debugInfoLabel->setVisible(m_showDebugInfo);
+
+    // Add toggle for debug info
+    QHBoxLayout* debugLayout = new QHBoxLayout();
+    QPushButton* debugButton = new QPushButton("Toggle Performance Info", this);
+    connect(debugButton, &QPushButton::clicked, [this]() {
+        m_showDebugInfo = !m_showDebugInfo;
+        m_debugInfoLabel->setVisible(m_showDebugInfo);
+    });
+    debugLayout->addWidget(debugButton);
+    controlLayout->addLayout(debugLayout);
+
+    mainLayout->addWidget(controlPanel);
+}
+
+void ElevationView3D::setupCamera()
+{
+    // Remove any existing controller
+    for (Qt3DCore::QComponent* component : m_camera->components()) {
+        m_camera->removeComponent(component);
+    }
+
+    if (m_firstPersonMode) {
+        // First person camera controller (for flythrough)
+        Qt3DExtras::QFirstPersonCameraController* camController = new Qt3DExtras::QFirstPersonCameraController(m_rootEntity);
+        camController->setCamera(m_camera);
+        camController->setLinearSpeed(50.0f);
+        camController->setLookSpeed(180.0f);
+    } else {
+        // Orbit camera controller (for overview)
+        Qt3DExtras::QOrbitCameraController* camController = new Qt3DExtras::QOrbitCameraController(m_rootEntity);
+        camController->setCamera(m_camera);
+        camController->setLinearSpeed(50.0f);
+        camController->setLookSpeed(180.0f);
+    }
+}
+
+void ElevationView3D::setTrackData(const std::vector<TrackPoint>& points)
+{
+    QElapsedTimer totalTimer;
+    totalTimer.start();
+    logInfo("ElevationView3D", QString("Starting 3D track data processing with %1 points").arg(points.size()));
+
+    if (points.empty()) {
+        logWarning("ElevationView3D", "No points provided, returning");
+        return;
+    }
+
+    // Use a guard flag to prevent reentrancy issues
+    static bool isUpdating = false;
+    if (isUpdating) {
+        logWarning("ElevationView3D", "Already updating, ignoring recursive call");
+        return;
+    }
+
+    // Set the guard flag
+    isUpdating = true;
+
+    // Use a single shot timer to defer processing and keep UI responsive
+    if (points.size() > 1000) {
+        logInfo("ElevationView3D", "Large dataset detected, deferring 3D processing");
+        QTimer::singleShot(100, this, [this, points]() {
+            this->processTrackDataDeferred(points);
+        });
+        isUpdating = false;
+        return;
+    }
+
+    try {
+        // Clear existing track data first to prevent access to invalid memory
+        logDebug("ElevationView3D", "Clearing track positions");
+        m_trackPositions.clear();
+
+        // Store original track points
+        logDebug("ElevationView3D", "Storing track points");
+        m_trackPoints = points;
+
+        // Safely clean up existing entities
+        safelyCleanupEntities();
+
+        // Ensure we have a valid root entity
+        logDebug("ElevationView3D", "Checking root entity");
+        if (!m_rootEntity || m_rootEntity->parent() == nullptr) {
+            logDebug("ElevationView3D", "Creating new root entity");
+            m_rootEntity = new Qt3DCore::QEntity();
+            if (m_3dWindow) {
+                m_3dWindow->setRootEntity(m_rootEntity);
+            } else {
+                logWarning("ElevationView3D", "No 3D window available");
+                isUpdating = false; // Reset guard flag
+                return;
+            }
+        }
+
+        // Convert track points to 3D positions
+        convertTrackPointsTo3D(points);
+
+        // Create new terrain and route entities
+        createSceneEntities();
+
+        // Fetch terrain data
+        if (!m_trackPoints.empty()) {
+            double minLat = m_trackPoints[0].coord.latitude();
+            double maxLat = m_trackPoints[0].coord.latitude();
+            double minLon = m_trackPoints[0].coord.longitude();
+            double maxLon = m_trackPoints[0].coord.longitude();
+            for (const auto& point : m_trackPoints) {
+                minLat = std::min(minLat, point.coord.latitude());
+                maxLat = std::max(maxLat, point.coord.latitude());
+                minLon = std::min(minLon, point.coord.longitude());
+                maxLon = std::max(maxLon, point.coord.longitude());
+            }
+            // Add a small buffer around the track
+            double latBuffer = (maxLat - minLat) * 0.1;
+            double lonBuffer = (maxLon - minLon) * 0.1;
+            m_terrainService->fetchTerrainData(maxLat + latBuffer, minLat - latBuffer, minLon - lonBuffer, maxLon + lonBuffer, 100, 100);
+        }
+
+        // Reset camera to view the entire route
+        resetCameraView();
+
+        logDebug("ElevationView3D", "Completed successfully");
+    } catch (const std::exception& e) {
+        logCritical("ElevationView3D", QString("Exception during processing: %1").arg(e.what()));
+    } catch (...) {
+        logCritical("ElevationView3D", "Unknown exception during processing");
+    }
+
+    // Reset the guard flag
+    isUpdating = false;
+
+    // The guard flag will be automatically reset when this function exits
+}
+
+// New method to defer processing of large track data sets to keep UI responsive
+void ElevationView3D::processTrackDataDeferred(const std::vector<TrackPoint>& points)
+{
+    QElapsedTimer totalTimer;
+    totalTimer.start();
+    static bool isUpdating = false;
+
+    if (isUpdating) {
+        logWarning("ElevationView3D", "Already processing in deferred mode, skipping");
+        return;
+    }
+
+    isUpdating = true;
+
+    try {
+        // Clear existing track data first to prevent access to invalid memory
+        logDebug("ElevationView3D", "Clearing track positions");
+        m_trackPositions.clear();
+        QCoreApplication::processEvents();
+
+        // Store original track points
+        logDebug("ElevationView3D", "Storing track points");
+        m_trackPoints = points;
+        QCoreApplication::processEvents();
+
+        // Safely clean up existing entities
+        safelyCleanupEntities();
+        QCoreApplication::processEvents();
+
+        // Ensure we have a valid root entity
+        logDebug("ElevationView3D", "Checking root entity");
+        if (!m_rootEntity || m_rootEntity->parent() == nullptr) {
+            logDebug("ElevationView3D", "Creating new root entity");
+            m_rootEntity = new Qt3DCore::QEntity();
+            if (m_3dWindow) {
+                m_3dWindow->setRootEntity(m_rootEntity);
+            } else {
+                logWarning("ElevationView3D", "No 3D window available");
+                isUpdating = false; // Reset guard flag
+                return;
+            }
+        }
+        QCoreApplication::processEvents();
+
+        // Convert track points to 3D positions - this can be intensive
+        QElapsedTimer timer;
+        timer.start();
+        logInfo("ElevationView3D", "Converting track points to 3D positions...");
+        convertTrackPointsTo3D(points);
+        logInfo("ElevationView3D", QString("Conversion completed in %1 ms").arg(timer.elapsed()));
+        QCoreApplication::processEvents();
+
+        // Create new terrain and route entities in stages
+        timer.restart();
+        logInfo("ElevationView3D", "Creating scene entities...");
+        createSceneEntities();
+        logInfo("ElevationView3D", QString("Scene creation completed in %1 ms").arg(timer.elapsed()));
+        QCoreApplication::processEvents();
+
+        // Reset camera to view the entire route
+        timer.restart();
+        logInfo("ElevationView3D", "Resetting camera view...");
+        resetCameraView();
+        logInfo("ElevationView3D", QString("Camera reset completed in %1 ms").arg(timer.elapsed()));
+
+        logInfo("ElevationView3D", QString("Total 3D processing completed in %1 ms").arg(totalTimer.elapsed()));
+    } catch (const std::exception& e) {
+        logCritical("ElevationView3D", QString("Exception during deferred processing: %1").arg(e.what()));
+    } catch (...) {
+        logCritical("ElevationView3D", "Unknown exception during deferred processing");
+    }
+
+    // Reset the guard flag
+    isUpdating = false;
+}
+
+void ElevationView3D::safelyCleanupEntities()
+{
+    qDebug() << "ElevationView3D::safelyCleanupEntities - Starting cleanup";
+
+    // Use standard approach without QPointer
+    QList<Qt3DCore::QEntity*> entitiesToDelete;
+
+    if (m_terrainEntity) {
+        entitiesToDelete.append(m_terrainEntity);
+        m_terrainEntity = nullptr;
+    }
+
+    if (m_routeEntity) {
+        entitiesToDelete.append(m_routeEntity);
+        m_routeEntity = nullptr;
+    }
+
+    if (m_markerEntity) {
+        entitiesToDelete.append(m_markerEntity);
+        m_markerEntity = nullptr;
+    }
+
+    // Process deletions more safely to avoid reentrancy and segfault issues
+    if (!entitiesToDelete.isEmpty()) {
+        // Critical fix: Create a heap-allocated copy of the entity list
+        // This ensures the entity list survives beyond this method's scope
+        auto* deleteList = new QList<Qt3DCore::QEntity*>(entitiesToDelete);
+
+        // Use a QObject to own the lambda, ensuring it's deleted after execution
+        QObject* cleanupHandler = new QObject(this);
+        // Use the C++11 lambda syntax that captures the deleteList by value
+        QTimer::singleShot(0, cleanupHandler, [cleanupHandler, deleteList]() {
+            // Process each entity in our heap-allocated list
+            for (Qt3DCore::QEntity* entity : *deleteList) {
+                if (entity) {
+                    // Just schedule deletion without modifying the entity
+                    entity->deleteLater();
+                }
+            }
+            // Clean up our heap-allocated list and the cleanup handler
+            delete deleteList;
+            cleanupHandler->deleteLater();
+        });
+    }
+
+    qDebug() << "ElevationView3D::safelyCleanupEntities - Scheduled" << entitiesToDelete.size()
+             << "entities for deletion";
+}
+
+void ElevationView3D::convertTrackPointsTo3D(const std::vector<TrackPoint>& points)
+{
+    qDebug() << "ElevationView3D::convertTrackPointsTo3D - Converting" << points.size() << "points";
+
+    // Pre-allocate memory to avoid reallocations
+    m_trackPositions.reserve(std::min(points.size(), size_t(10000)));
+
+    // Sample a subset of points if there are too many
+    const size_t MAX_POINTS_TO_RENDER = 5000; // Limit for very large datasets
+    size_t sampleEvery = (points.size() > MAX_POINTS_TO_RENDER) ?
+        points.size() / MAX_POINTS_TO_RENDER + 1 : 1;
+
+    if (sampleEvery > 1) {
+        qDebug() << "ElevationView3D::convertTrackPointsTo3D - Sampling every" << sampleEvery
+                 << "points due to large dataset";
+    }
+
+    // Convert points to 3D positions
+    for (size_t i = 0; i < points.size(); i += sampleEvery) {
+        m_trackPositions.push_back(trackPointToVector3D(points[i]));
+    }
+
+    // Always ensure the last point is included for proper route termination
+    if (!points.empty()) {
+        QVector3D lastPoint = trackPointToVector3D(points.back());
+        if (m_trackPositions.empty() || m_trackPositions.back() != lastPoint) {
+            m_trackPositions.push_back(lastPoint);
+        }
+    }
+
+    qDebug() << "ElevationView3D::convertTrackPointsTo3D - Processed" << m_trackPositions.size()
+             << "3D positions";
+}
+
+void ElevationView3D::createSceneEntities()
+{
+    // Only proceed if we have valid track positions
+    if (m_trackPositions.empty()) {
+        qWarning() << "ElevationView3D::createSceneEntities - No track positions available";
+        return;
+    }
+
+    // Create terrain mesh
+    qDebug() << "ElevationView3D::createSceneEntities - Creating terrain";
+    createTerrain();
+
+    // Create route visualization
+    qDebug() << "ElevationView3D::createSceneEntities - Creating route";
+    createRoute();
+
+    // Create position marker
+    qDebug() << "ElevationView3D::createSceneEntities - Creating marker";
+    createMarker();
+}
+
+void ElevationView3D::resetCameraView()
+{
+    if (m_trackPositions.empty() || !m_camera) {
+        return;
+    }
+
+    qDebug() << "ElevationView3D::resetCameraView - Resetting camera position";
+
+    // Find bounding box of the route
+    QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+    QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+
+    for (const auto& pos : m_trackPositions) {
+        routeMin.setX(std::min(routeMin.x(), pos.x()));
+        routeMin.setY(std::min(routeMin.y(), pos.y()));
+        routeMin.setZ(std::min(routeMin.z(), pos.z()));
+
+        routeMax.setX(std::max(routeMax.x(), pos.x()));
+        routeMax.setY(std::max(routeMax.y(), pos.y()));
+        routeMax.setZ(std::max(routeMax.z(), pos.z()));
+    }
+
+    // Calculate center and size of the route
+    QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
+    float routeSize = (routeMax - routeMin).length();
+
+    // Position camera to view the entire route
+    m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
+    m_camera->setViewCenter(routeCenter);
+
+    // Reset animation parameters
+    m_flythroughProgress = 0.0f;
+    m_currentPositionIndex = 0;
+
+    // Update marker to first position if it exists
+    if (m_markerEntity && !m_trackPositions.empty()) {
+        updateMarkerPosition(0);
+    }
+
+    qDebug() << "ElevationView3D::setTrackData - Completed successfully";
+}
+
+void ElevationView3D::createTerrain()
+{
+    // This method is now effectively a placeholder.
+    // The terrain is created when the terrain data is ready in onTerrainDataReady.
+    // We could potentially create a placeholder flat terrain here while the real data loads.
+    qDebug() << "ElevationView3D::createTerrain - Deferred to onTerrainDataReady";
+}
+
+void ElevationView3D::createRoute()
+{
+    qDebug() << "ElevationView3D::createRoute - Starting";
+
+    // Ensure we're not creating route with invalid data
+    if (m_trackPoints.empty()) {
+        qWarning() << "ElevationView3D::createRoute - No track points available";
+        return;
+    }
+
+    try {
+        QElapsedTimer timer;
+        timer.start();
+
+        m_routeEntity = createOptimizedRoutePath(m_trackPoints);
+        if (m_routeEntity && m_rootEntity) {
+            qDebug() << "ElevationView3D::createRoute - Setting parent to root entity";
+            m_routeEntity->setParent(m_rootEntity);
+        } else {
+            qWarning() << "ElevationView3D::createRoute - Failed to create route path or no root entity";
+            if (m_routeEntity) {
+                m_routeEntity->deleteLater();
+                m_routeEntity = nullptr;
+            }
+        }
+
+        qDebug() << "ElevationView3D::createRoute - Completed in" << timer.elapsed() << "ms";
+    } catch (const std::exception& e) {
+        qCritical() << "ElevationView3D::createRoute - Exception:" << e.what();
+    } catch (...) {
+        qCritical() << "ElevationView3D::createRoute - Unknown exception";
+    }
+}
+
+void ElevationView3D::createMarker()
+{
+    qDebug() << "ElevationView3D::createMarker - Starting";
+
+    try {
+        m_markerEntity = createPositionMarker();
+        if (m_markerEntity && m_rootEntity) {
+            qDebug() << "ElevationView3D::createMarker - Setting parent to root entity";
+            m_markerEntity->setParent(m_rootEntity);
+
+            // Position at start of route
+            if (!m_trackPositions.empty()) {
+                qDebug() << "ElevationView3D::createMarker - Updating marker position";
+                updateMarkerPosition(0);
+            } else {
+                qWarning() << "ElevationView3D::createMarker - No track positions available";
+            }
+        } else {
+            qWarning() << "ElevationView3D::createMarker - Failed to create position marker or no root entity";
+            if (m_markerEntity) {
+                m_markerEntity->deleteLater();
+                m_markerEntity = nullptr;
+            }
+        }
+    } catch (const std::exception& e) {
+        qCritical() << "ElevationView3D::createMarker - Exception:" << e.what();
+    } catch (...) {
+        qCritical() << "ElevationView3D::createMarker - Unknown exception";
+    }
+
+    qDebug() << "ElevationView3D::createMarker - Completed";
+}
+
+Qt3DCore::QEntity* ElevationView3D::createTerrainMesh(const TerrainData& terrainData)
+{
+    qDebug() << "ElevationView3D::createTerrainMesh - Creating mesh from terrain data";
+
+    if (terrainData.elevationGrid.empty() || terrainData.elevationGrid[0].empty()) {
+        qWarning() << "ElevationView3D::createTerrainMesh - No elevation data provided, returning nullptr";
+        return nullptr;
+    }
+
+    Qt3DCore::QEntity* terrainEntity = new Qt3DCore::QEntity();
+    Qt3DRender::QGeometryRenderer* meshRenderer = new Qt3DRender::QGeometryRenderer();
+    Qt3DRender::QGeometry* geometry = new Qt3DRender::QGeometry(meshRenderer);
+
+    QByteArray vertexBufferData;
+    int gridHeight = terrainData.elevationGrid.size();
+    int gridWidth = terrainData.elevationGrid[0].size();
+    vertexBufferData.resize(gridWidth * gridHeight * (3 + 3 + 2) * sizeof(float));
+    float* p = reinterpret_cast<float*>(vertexBufferData.data());
+
+    // This is a simplified conversion from lat/lon to a flat 3D space.
+    // It is not accurate for large areas but is sufficient for this visualization.
+    const double latToMeters = 111320.0;
+    const double lonToMeters = 40075000.0 * cos(terrainData.topLeft.latitude() * M_PI / 180.0) / 360.0;
+
+    double widthMeters = (terrainData.bottomRight.longitude() - terrainData.topLeft.longitude()) * lonToMeters;
+    double heightMeters = (terrainData.topLeft.latitude() - terrainData.bottomRight.latitude()) * latToMeters;
+
+
+    for (int i = 0; i < gridHeight; ++i) {
+        for (int j = 0; j < gridWidth; ++j) {
+            // Position
+            float x = (float)(j * widthMeters / (gridWidth - 1));
+            float z = (float)(i * heightMeters / (gridHeight - 1));
+            float y = terrainData.elevationGrid[i][j] * m_elevationScale;
+            *p++ = x;
+            *p++ = y;
+            *p++ = z;
+
+            // Normals (temporary, will be properly calculated later)
+            *p++ = 0.0f;
+            *p++ = 1.0f;
+            *p++ = 0.0f;
+
+            // Texture coordinates
+            *p++ = (float)j / (gridWidth - 1);
+            *p++ = (float)i / (gridHeight - 1);
+        }
+    }
+
+    QByteArray indexBufferData;
+    indexBufferData.resize((gridWidth - 1) * (gridHeight - 1) * 6 * sizeof(unsigned int));
+    unsigned int* indices = reinterpret_cast<unsigned int*>(indexBufferData.data());
+    for (int i = 0; i < gridHeight - 1; ++i) {
+        for (int j = 0; j < gridWidth - 1; ++j) {
+            unsigned int i0 = i * gridWidth + j;
+            unsigned int i1 = i0 + 1;
+            unsigned int i2 = (i + 1) * gridWidth + j;
+            unsigned int i3 = i2 + 1;
+            *indices++ = i0; *indices++ = i2; *indices++ = i1;
+            *indices++ = i1; *indices++ = i2; *indices++ = i3;
+        }
+    }
+
+    Qt3DRender::QBuffer* vertexBuffer = new Qt3DRender::QBuffer(geometry);
+    vertexBuffer->setData(vertexBufferData);
+
+    Qt3DRender::QBuffer* indexBuffer = new Qt3DRender::QBuffer(geometry);
+    indexBuffer->setData(indexBufferData);
+
+    // Attributes
+    int stride = (3 + 3 + 2) * sizeof(float);
+    Qt3DRender::QAttribute* posAttr = new Qt3DRender::QAttribute();
+    posAttr->setName(Qt3DRender::QAttribute::defaultPositionAttributeName());
+    posAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    posAttr->setBuffer(vertexBuffer);
+    posAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    posAttr->setVertexSize(3);
+    posAttr->setByteOffset(0);
+    posAttr->setByteStride(stride);
+    posAttr->setCount(gridWidth * gridHeight);
+
+    Qt3DRender::QAttribute* normAttr = new Qt3DRender::QAttribute();
+    normAttr->setName(Qt3DRender::QAttribute::defaultNormalAttributeName());
+    normAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    normAttr->setBuffer(vertexBuffer);
+    normAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    normAttr->setVertexSize(3);
+    normAttr->setByteOffset(3 * sizeof(float));
+    normAttr->setByteStride(stride);
+    normAttr->setCount(gridWidth * gridHeight);
+
+    Qt3DRender::QAttribute* texAttr = new Qt3DRender::QAttribute();
+    texAttr->setName(Qt3DRender::QAttribute::defaultTextureCoordinateAttributeName());
+    texAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    texAttr->setBuffer(vertexBuffer);
+    texAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    texAttr->setVertexSize(2);
+    texAttr->setByteOffset((3 + 3) * sizeof(float));
+    texAttr->setByteStride(stride);
+    texAttr->setCount(gridWidth * gridHeight);
+
+    Qt3DRender::QAttribute* indexAttr = new Qt3DRender::QAttribute();
+    indexAttr->setAttributeType(Qt3DRender::QAttribute::IndexAttribute);
+    indexAttr->setBuffer(indexBuffer);
+    indexAttr->setVertexBaseType(Qt3DRender::QAttribute::UnsignedInt);
+    indexAttr->setCount((gridWidth - 1) * (gridHeight - 1) * 6);
+
+    geometry->addAttribute(posAttr);
+    geometry->addAttribute(normAttr);
+    geometry->addAttribute(texAttr);
+    geometry->addAttribute(indexAttr);
+
+    meshRenderer->setGeometry(geometry);
+    meshRenderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+
+    // Material
+    Qt3DExtras::QDiffuseSpecularMaterial* material = new Qt3DExtras::QDiffuseSpecularMaterial();
+    if (!terrainData.satelliteImagePath.isEmpty()) {
+        Qt3DRender::QTexture2D* texture = new Qt3DRender::QTexture2D();
+        Qt3DRender::QTextureImage* textureImage = new Qt3DRender::QTextureImage();
+        textureImage->setSource(QUrl::fromLocalFile(terrainData.satelliteImagePath));
+        texture->addTextureImage(textureImage);
+        material->setDiffuse(QVariant::fromValue(texture));
+        material->setShininess(10.0f);
+    } else {
+        material->setDiffuse(QColor(Qt::darkGray));
+    }
+
+    terrainEntity->addComponent(meshRenderer);
+    terrainEntity->addComponent(material);
+    terrainEntity->addComponent(new Qt3DCore::QTransform());
+
+    return terrainEntity;
+}
+
+Qt3DCore::QEntity* ElevationView3D::createOptimizedRoutePath(const std::vector<TrackPoint>& points)
+{
+    if (points.size() < 2) {
+        return nullptr;
+    }
+
+    // Create the root route entity
+    Qt3DCore::QEntity* routeEntity = new Qt3DCore::QEntity();
+
+    // Simplify the route if it's too detailed
+    std::vector<TrackPoint> simplifiedPoints;
+    simplifyRoute(points, simplifiedPoints, MAX_ROUTE_VERTICES);
+
+    // Group segments into batches for better performance
+    size_t currentBatch = 0;
+    size_t totalBatches = (simplifiedPoints.size() / ROUTE_SEGMENT_BATCH_SIZE) + 1;
+
+    while (currentBatch < totalBatches) {
+        // Create custom mesh entity for this batch
+        size_t startIdx = currentBatch * ROUTE_SEGMENT_BATCH_SIZE;
+        size_t endIdx = std::min(startIdx + ROUTE_SEGMENT_BATCH_SIZE, simplifiedPoints.size() - 1);
+
+        // Skip if we don't have enough points for this batch
+        if (startIdx >= simplifiedPoints.size() - 1) {
+            break;
+        }
+
+        // Create a batch entity
+        createBatchedSegments(routeEntity, simplifiedPoints, startIdx, endIdx);
+        currentBatch++;
+    }
+
+    return routeEntity;
+}
+
+void ElevationView3D::createBatchedSegments(Qt3DCore::QEntity* parentEntity,
+                                          const std::vector<TrackPoint>& points,
+                                          size_t startIdx, size_t endIdx)
+{
+    qDebug() << "ElevationView3D::createBatchedSegments - Starting for indices"
+             << startIdx << "to" << endIdx << "(total points:" << points.size() << ")";
+
+    if (startIdx >= points.size() - 1 || endIdx >= points.size()) {
+        qWarning() << "ElevationView3D::createBatchedSegments - Invalid indices, returning";
+        return;
+    }
+
+    // Create entity for this batch
+    Qt3DCore::QEntity* batchEntity = new Qt3DCore::QEntity(parentEntity);
+
+    // Create a custom mesh for better performance
+    Qt3DRender::QGeometry* geometry = new Qt3DRender::QGeometry(batchEntity);
+
+    // Create buffers with correct UsageType enum values
+    Qt3DRender::QBuffer* positionBuffer = new Qt3DRender::QBuffer(geometry);
+    positionBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw); // Changed from VertexBuffer to StaticDraw
+
+    Qt3DRender::QBuffer* indexBuffer = new Qt3DRender::QBuffer(geometry);
+    indexBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw);  // Changed from IndexBuffer to StaticDraw
+
+    Qt3DRender::QBuffer* colorBuffer = new Qt3DRender::QBuffer(geometry);
+    colorBuffer->setUsage(Qt3DRender::QBuffer::StaticDraw);  // Changed from VertexBuffer to StaticDraw
+
+    // Calculate average color and gradient for this batch
+    QVector<QVector3D> positions;
+    QVector<QVector3D> colors;
+    QVector<uint> indices;
+
+    const float lineRadius = 0.4f; // Thinner lines for better performance
+    int segmentResolution = 6; // Lower resolution for better performance
+
+    // Generate a cylinder-like geometry for each segment
+    for (size_t i = startIdx; i < endIdx; i++) {
+        // Calculate segment properties
+        QVector3D start = trackPointToVector3D(points[i]);
+        QVector3D end = trackPointToVector3D(points[i + 1]);
+
+        // Calculate segment color based on gradient
+        float gradient = 0.0f;
+        if (i < points.size() - 1) {
+            float elevDiff = points[i + 1].elevation - points[i].elevation;
+            float distance = points[i + 1].distance - points[i].distance;
+            if (distance > 0) {
+                gradient = (elevDiff / distance) * 100.0f;
+            }
+        }
+
+        // Choose color based on gradient
+        QVector3D segmentColor;
+        if (gradient > 10.0f) {
+            segmentColor = QVector3D(1.0f, 0.0f, 0.0f); // Steep climb - red
+        } else if (gradient > 5.0f) {
+            segmentColor = QVector3D(1.0f, 0.65f, 0.0f); // Moderate climb - orange
+        } else if (gradient > 2.0f) {
+            segmentColor = QVector3D(1.0f, 1.0f, 0.0f); // Mild climb - yellow
+        } else if (gradient < -10.0f) {
+            segmentColor = QVector3D(0.5f, 0.0f, 0.5f); // Steep descent - purple
+        } else if (gradient < -5.0f) {
+            segmentColor = QVector3D(0.0f, 0.0f, 1.0f); // Moderate descent - blue
+        } else if (gradient < -2.0f) {
+            segmentColor = QVector3D(0.4f, 0.7f, 1.0f); // Mild descent - light blue
+        } else {
+            segmentColor = QVector3D(0.0f, 0.5f, 0.0f); // Flat - green
+        }
+
+        // Calculate segment direction
+        QVector3D direction = end - start;
+        direction.normalize();
+
+        // Define cylinder vertices around the segment
+        QVector3D right, up;
+
+        // Find perpendicular vectors to create a cylinder
+        if (qAbs(direction.y()) > 0.99f) {
+            right = QVector3D(1.0f, 0.0f, 0.0f); // Handle vertical segments
+        } else {
+            right = QVector3D::crossProduct(direction, QVector3D(0.0f, 1.0f, 0.0f)).normalized();
+        }
+        up = QVector3D::crossProduct(right, direction).normalized();
+
+        // Starting index for this segment
+        uint baseIndex = positions.size();
+
+        // Generate a simpler tube for the segment
+        for (int j = 0; j < segmentResolution; j++) {
+            float angle = j * 2.0f * M_PI / segmentResolution;
+            float x = ::cos(angle);
+            float y = ::sin(angle);
+
+            // Add vertex at the start cap
+            QVector3D offset = right * x * lineRadius + up * y * lineRadius;
+            positions.append(start + offset);
+            colors.append(segmentColor);
+
+            // Add vertex at the end cap
+            positions.append(end + offset);
+            colors.append(segmentColor);
+
+            // Add indices for triangles (2 triangles per side of cylinder)
+            uint nextJ = (j + 1) % segmentResolution;
+            uint curr1 = baseIndex + j * 2;
+            uint curr2 = baseIndex + j * 2 + 1;
+            uint next1 = baseIndex + nextJ * 2;
+            uint next2 = baseIndex + nextJ * 2 + 1;
+
+            // First triangle
+            indices.append(curr1);
+            indices.append(next1);
+            indices.append(curr2);
+
+            // Second triangle
+            indices.append(curr2);
+            indices.append(next1);
+            indices.append(next2);
+        }
+    }
+
+    // Set buffer data
+    QByteArray positionData(reinterpret_cast<const char*>(positions.constData()),
+                          positions.size() * 3 * sizeof(float));
+    positionBuffer->setData(positionData);
+
+    QByteArray colorData(reinterpret_cast<const char*>(colors.constData()),
+                       colors.size() * 3 * sizeof(float));
+    colorBuffer->setData(colorData);
+
+    QByteArray indexData(reinterpret_cast<const char*>(indices.constData()),
+                       indices.size() * sizeof(uint));
+    indexBuffer->setData(indexData);
+
+    // Add attributes to the geometry
+    Qt3DRender::QAttribute* positionAttribute = new Qt3DRender::QAttribute(geometry);
+    positionAttribute->setName(Qt3DRender::QAttribute::defaultPositionAttributeName());
+    positionAttribute->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    positionAttribute->setVertexSize(3);
+    positionAttribute->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    positionAttribute->setBuffer(positionBuffer);
+    positionAttribute->setByteOffset(0);
+    positionAttribute->setByteStride(3 * sizeof(float));
+    positionAttribute->setCount(positions.size());
+    geometry->addAttribute(positionAttribute);
+
+    Qt3DRender::QAttribute* colorAttribute = new Qt3DRender::QAttribute(geometry);
+    colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
+    colorAttribute->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    colorAttribute->setVertexSize(3);
+    colorAttribute->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    colorAttribute->setBuffer(colorBuffer);
+    colorAttribute->setByteOffset(0);
+    colorAttribute->setByteStride(3 * sizeof(float));
+    colorAttribute->setCount(colors.size());
+    geometry->addAttribute(colorAttribute);
+
+    Qt3DRender::QAttribute* indexAttribute = new Qt3DRender::QAttribute(geometry);
+    indexAttribute->setAttributeType(Qt3DRender::QAttribute::IndexAttribute);
+    indexAttribute->setVertexBaseType(Qt3DRender::QAttribute::UnsignedInt);
+    indexAttribute->setBuffer(indexBuffer);
+    indexAttribute->setCount(indices.size());
+    geometry->addAttribute(indexAttribute);
+
+    // Create a geometry renderer
+    Qt3DRender::QGeometryRenderer* mesh = new Qt3DRender::QGeometryRenderer();
+    mesh->setGeometry(geometry);
+    mesh->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+
+    // Create material - use faster PhongAlphaMaterial
+    Qt3DExtras::QPhongAlphaMaterial* material = new Qt3DExtras::QPhongAlphaMaterial();
+    material->setAmbient(QColor(50, 50, 50));
+    material->setDiffuse(QColor(180, 180, 180)); // Will be modulated by vertex colors
+    material->setSpecular(QColor(80, 80, 80));
+    material->setShininess(20.0f);
+    material->setAlpha(1.0f);
+
+    // Add components to entity
+    batchEntity->addComponent(mesh);
+    batchEntity->addComponent(material);
+}
+
+// New helper method to simplify route points for better performance
+void ElevationView3D::simplifyRoute(const std::vector<TrackPoint>& input,
+                                  std::vector<TrackPoint>& output,
+                                  int maxPoints)
+{
+    qDebug() << "ElevationView3D::simplifyRoute - Starting with" << input.size()
+             << "points, max output =" << maxPoints;
+
+    output.clear(); // Make sure output is empty before starting
+
+    if (input.empty()) {
+        qWarning() << "ElevationView3D::simplifyRoute - No input points, returning early";
+        return; // Return early if there's no input
+    }
+
+    try {
+        if (static_cast<size_t>(maxPoints) >= input.size()) {
+            // No simplification needed
+            qDebug() << "ElevationView3D::simplifyRoute - No simplification needed, copying all points";
+            output = input;
+            return;
+        }
+
+        // Calculate how many points to keep
+        int keepEveryNth = std::max(1, static_cast<int>(input.size() / maxPoints));
+        qDebug() << "ElevationView3D::simplifyRoute - Will keep every" << keepEveryNth << "point";
+
+        // Allocate enough space upfront to avoid reallocations
+        output.reserve(maxPoints + 2);
+
+        // Start with the first point
+        output.push_back(input.front());
+
+        // Add the subset of points
+        for (size_t i = 1; i < input.size() - 1; i += keepEveryNth) {
+            output.push_back(input[i]);
+        }
+
+        // Always add the last point if not already added
+        if (output.size() == 1 || output.back().coord != input.back().coord) {
+            output.push_back(input.back());
+        }
+
+        qDebug() << "ElevationView3D::simplifyRoute - Route simplified from" << input.size()
+                 << "to" << output.size() << "points";
+    } catch (const std::exception& e) {
+        qCritical() << "ElevationView3D::simplifyRoute - Exception:" << e.what();
+    } catch (...) {
+        qCritical() << "ElevationView3D::simplifyRoute - Unknown exception occurred";
+    }
+}
+
+Qt3DCore::QEntity* ElevationView3D::createPositionMarker()
+{
+    // Create a sphere to represent the current position
+    Qt3DCore::QEntity* markerEntity = new Qt3DCore::QEntity();
+
+    // Create mesh
+    Qt3DExtras::QSphereMesh* markerMesh = new Qt3DExtras::QSphereMesh();
+    markerMesh->setRadius(MARKER_SIZE);
+    markerMesh->setRings(16);
+    markerMesh->setSlices(16);
+
+    // Create material
+    Qt3DExtras::QDiffuseSpecularMaterial* markerMaterial = new Qt3DExtras::QDiffuseSpecularMaterial();
+    markerMaterial->setDiffuse(QColor(255, 0, 0));
+    markerMaterial->setSpecular(QColor(255, 255, 255));
+    markerMaterial->setShininess(50.0f);
+
+    // Create transform
+    Qt3DCore::QTransform* markerTransform = new Qt3DCore::QTransform();
+
+    // Add components
+    markerEntity->addComponent(markerMesh);
+    markerEntity->addComponent(markerMaterial);
+    markerEntity->addComponent(markerTransform);
+
+    return markerEntity;
+}
+
+void ElevationView3D::updateMarkerPosition(size_t pointIndex)
+{
+    qDebug() << "ElevationView3D::updateMarkerPosition - Updating to index" << pointIndex
+             << "(total positions:" << m_trackPositions.size() << ")";
+
+    if (pointIndex >= m_trackPositions.size() || !m_markerEntity) {
+        qWarning() << "ElevationView3D::updateMarkerPosition - Invalid index or no marker entity, returning";
+        return;
+    }
+
+    m_currentPositionIndex = pointIndex;
+
+    // Update marker position
+    Qt3DCore::QTransform* markerTransform = m_markerEntity->findChild<Qt3DCore::QTransform*>();
+    if (markerTransform) {
+        markerTransform->setTranslation(m_trackPositions[pointIndex]);
+    } else {
+        qWarning() << "ElevationView3D::updateMarkerPosition - No transform component found on marker";
+    }
+}
+
+void ElevationView3D::updatePosition(size_t pointIndex)
+{
+    if (pointIndex >= m_trackPositions.size()) {
+        return;
+    }
+
+    // Update marker
+    updateMarkerPosition(pointIndex);
+
+    // If in first-person mode, update camera position
+    if (m_firstPersonMode && !m_flythroughActive) {
+        // Get current position
+        QVector3D currentPos = m_trackPositions[pointIndex];
+
+        // Calculate look direction
+        QVector3D lookDir;
+        if (pointIndex < m_trackPositions.size() - 1) {
+            lookDir = (m_trackPositions[pointIndex + 1] - currentPos).normalized();
+        } else if (pointIndex > 0) {
+            lookDir = (currentPos - m_trackPositions[pointIndex - 1]).normalized();
+        } else {
+            lookDir = QVector3D(1, 0, 0); // Default look direction
+        }
+
+        // Apply camera tilt
+        QVector3D upVector(0, 1, 0);
+        QQuaternion tiltRotation = QQuaternion::fromAxisAndAngle(
+            QVector3D::crossProduct(lookDir, upVector).normalized(),
+            -m_cameraTilt
+        );
+        lookDir = tiltRotation.rotatedVector(lookDir);
+
+        // Set camera position slightly above the track
+        QVector3D cameraPos = currentPos + QVector3D(0, 1.5f, 0);
+        QVector3D lookTarget = cameraPos + lookDir * 10.0f;
+
+        // Update camera
+        m_camera->setPosition(cameraPos);
+        m_camera->setViewCenter(lookTarget);
+    }
+}
+
+void ElevationView3D::startFlythrough()
+{
+    if (m_trackPositions.empty()) {
+        return;
+    }
+
+    // Start animation
+    m_flythroughActive = true;
+    m_flythroughTimer->start();
+
+    // Switch to first-person mode
+    m_firstPersonMode = true;
+    setupCamera();
+
+    // Set camera to starting position
+    m_flythroughProgress = 0.0f;
+    updateFlythrough();
+}
+
+void ElevationView3D::pauseFlythrough()
+{
+    m_flythroughActive = !m_flythroughActive;
+
+    if (m_flythroughActive) {
+        m_flythroughTimer->start();
+    } else {
+        m_flythroughTimer->stop();
+    }
+}
+
+void ElevationView3D::stopFlythrough()
+{
+    // Stop the animation
+    m_flythroughActive = false;
+    m_flythroughTimer->stop();
+    m_flythroughProgress = 0.0f;
+
+    // Reset camera to overview mode
+    m_firstPersonMode = false;
+    setupCamera();
+
+    // Reset marker to start
+    updateMarkerPosition(0);
+
+    // Reset camera to view the entire route
+    if (!m_trackPositions.empty()) {
+        // Find center of route
+        QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+        QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+
+        for (const auto& pos : m_trackPositions) {
+            routeMin.setX(std::min(routeMin.x(), pos.x()));
+            routeMin.setY(std::min(routeMin.y(), pos.y()));
+            routeMin.setZ(std::min(routeMin.z(), pos.z()));
+
+            routeMax.setX(std::max(routeMax.x(), pos.x()));
+            routeMax.setY(std::max(routeMax.y(), pos.y()));
+            routeMax.setZ(std::max(routeMax.z(), pos.z()));
+        }
+
+        QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
+        float routeSize = (routeMax - routeMin).length();
+
+        // Position camera to view the entire route
+        m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
+        m_camera->setViewCenter(routeCenter);
+    }
+
+    // Emit position changed signal for the first point
+    emit positionChanged(0);
+}
+
+void ElevationView3D::toggleCameraMode()
+{
+    m_firstPersonMode = !m_firstPersonMode;
+    setupCamera();
+
+    if (m_firstPersonMode) {
+        // In first-person mode, move camera to current position
+        updatePosition(m_currentPositionIndex);
+    } else {
+        // In overview mode, show entire route
+        if (!m_trackPositions.empty()) {
+            // Find center of route
+            QVector3D routeMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+            QVector3D routeMax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+
+            for (const auto& pos : m_trackPositions) {
+                routeMin.setX(std::min(routeMin.x(), pos.x()));
+                routeMin.setY(std::min(routeMin.y(), pos.y()));
+                routeMin.setZ(std::min(routeMin.z(), pos.z()));
+
+                routeMax.setX(std::max(routeMax.x(), pos.x()));
+                routeMax.setY(std::max(routeMax.y(), pos.y()));
+                routeMax.setZ(std::max(routeMax.z(), pos.z()));
+            }
+
+            QVector3D routeCenter = (routeMin + routeMax) * 0.5f;
+            float routeSize = (routeMax - routeMin).length();
+
+            // Position camera to view the entire route
+            m_camera->setPosition(routeCenter + QVector3D(routeSize * 0.5f, routeSize * 0.5f, routeSize * 0.5f));
+            m_camera->setViewCenter(routeCenter);
+        }
+    }
+}
+
+void ElevationView3D::setElevationScale(float scale)
+{
+    if (qFuzzyCompare(m_elevationScale, scale)) {
+        return;
+    }
+
+    // Store new scale
+    m_elevationScale = scale;
+
+    // Regenerate the visualization with the new scale
+    if (!m_trackPoints.empty()) {
+        setTrackData(m_trackPoints);
+    }
+}
+
+void ElevationView3D::setCameraTilt(float angle)
+{
+    m_cameraTilt = angle;
+
+    // Update camera view if in first person mode
+    if (m_firstPersonMode && !m_flythroughActive) {
+        updatePosition(m_currentPositionIndex);
+    }
+}
+
+void ElevationView3D::updateFlythrough()
+{
+    if (!m_flythroughActive || m_trackPositions.size() < 2) {
+        return;
+    }
+
+    // Limit updates if we're running slowly
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (now - m_lastUpdateTime < DEFAULT_FLYTHROUGH_INTERVAL) {
+        return; // Skip this update to maintain performance
+    }
+    m_lastUpdateTime = now;
+
+    // Increment progress along the route
+    m_flythroughProgress += m_flythroughSpeed;
+
+    // Check if we've completed the route
+    if (m_flythroughProgress >= 1.0f) {
+        stopFlythrough();
+        return;
+    }
+
+    // Find current position in the route
+    size_t pointIndex = findClosestPointOnRoute(m_flythroughProgress);
+
+    // Update marker to current position
+    updateMarkerPosition(pointIndex);
+
+    // Emit position changed signal
+    emit positionChanged(static_cast<int>(pointIndex));
+
+    // Calculate camera position
+    QVector3D currentPos = m_trackPositions[pointIndex];
+
+    // Calculate look direction (toward next point)
+    QVector3D lookDir;
+    if (pointIndex < m_trackPositions.size() - 1) {
+        lookDir = (m_trackPositions[pointIndex + 1] - currentPos).normalized();
+    } else {
+        lookDir = (currentPos - m_trackPositions[pointIndex - 1]).normalized();
+    }
+
+    // Apply camera tilt
+    QVector3D upVector(0, 1, 0);
+    QQuaternion tiltRotation = QQuaternion::fromAxisAndAngle(
+        QVector3D::crossProduct(lookDir, upVector).normalized(),
+        -m_cameraTilt
+    );
+    lookDir = tiltRotation.rotatedVector(lookDir);
+
+    // Set camera position slightly above the track
+    QVector3D cameraPos = currentPos + QVector3D(0, 1.5f, 0);
+    QVector3D lookTarget = cameraPos + lookDir * 10.0f;
+
+    // Update camera
+    m_camera->setPosition(cameraPos);
+    m_camera->setViewCenter(lookTarget);
+}
+
+size_t ElevationView3D::findClosestPointOnRoute(float progress)
+{
+    if (m_trackPositions.empty()) {
+        return 0;
+    }
+
+    // Calculate total route length
+    float totalLength = 0.0f;
+    std::vector<float> cumulativeDistances;
+    cumulativeDistances.push_back(0.0f);
+
+    for (size_t i = 1; i < m_trackPositions.size(); i++) {
+        float segmentLength = (m_trackPositions[i] - m_trackPositions[i-1]).length();
+        totalLength += segmentLength;
+        cumulativeDistances.push_back(totalLength);
+    }
+
+    // Normalize to 0.0 - 1.0
+    for (auto& dist : cumulativeDistances) {
+        dist /= totalLength;
+    }
+
+    // Find the segment containing the target progress
+    float targetDist = progress;
+
+    for (size_t i = 0; i < cumulativeDistances.size() - 1; i++) {
+        if (targetDist >= cumulativeDistances[i] && targetDist <= cumulativeDistances[i+1]) {
+            // The target is between i and i+1
+            return i;
+        }
+    }
+
+    // If we get here, we're at the end of the route
+    return m_trackPositions.size() - 1;
+}
+
+void ElevationView3D::updateAnimationSpeed()
+{
+    // No need to adjust timer interval, the speed is controlled by progress increment
+}
+
+QVector3D ElevationView3D::trackPointToVector3D(const TrackPoint& point, bool scaleElevation)
+{
+    // For visualization purpose, convert GPS coordinates to a local 3D space
+    static double originLat = 0.0;
+    static double originLon = 0.0;
+
+    // Set origin to the first point in the track if not yet set
+    if (qFuzzyIsNull(originLat) && qFuzzyIsNull(originLon) && !m_trackPoints.empty()) {
+        originLat = m_trackPoints[0].coord.latitude();
+        originLon = m_trackPoints[0].coord.longitude();
+        qDebug() << "ElevationView3D::trackPointToVector3D - Set origin to"
+                 << originLat << "," << originLon;
+    }
+
+    // Scale factor to convert degrees to a reasonable distance in 3D space
+    // Using an approximate conversion (111.32 km per degree latitude)
+    const double scale = 111320.0 / 10.0; // Scale down by a factor of 10
+
+    // Calculate X (east-west) component - use cos from cmath directly
+    double x = (point.coord.longitude() - originLon) * scale * ::cos(originLat * M_PI / 180.0);
+
+    // Calculate Z (north-south) component
+    double z = (point.coord.latitude() - originLat) * scale;
+
+    // Y is elevation
+    double y = point.elevation;
+    if (scaleElevation) {
+        y *= m_elevationScale;
+    }
+
+    QVector3D result(x, y, z);
+    // Only log occasionally to avoid flooding the console
+    // Fix: Replace deprecated qrand() with QRandomGenerator
+    if (QRandomGenerator::global()->bounded(1000) == 0) {
+        qDebug() << "ElevationView3D::trackPointToVector3D - Converted"
+                 << point.coord.latitude() << "," << point.coord.longitude()
+                 << "," << point.elevation << "to" << result;
+    }
+
+    return result;
+}
+
+void ElevationView3D::setCameraPosition(const QVector3D& position, const QVector3D& target)
+{
+    m_camera->setPosition(position);
+    m_camera->setViewCenter(target);
+}
+
+void ElevationView3D::updateFPS()
+{
+    // Calculate frames per second
+    qint64 elapsed = m_frameCounter.elapsed();
+    m_fps = m_frameCount * 1000.0 / elapsed;
+    m_frameCount = 0;
+    m_frameCounter.restart();
+
+    // Update debug info
+    if (m_showDebugInfo) {
+        QString debugText = QString("FPS: %1\n").arg(m_fps, 0, 'f', 1);
+        debugText += QString("Points: %1\n").arg(m_trackPositions.size());
+        debugText += QString("Elev. Scale: %1x\n").arg(m_elevationScale);
+        debugText += QString("Camera Mode: %1\n").arg(m_firstPersonMode ? "First-Person" : "Orbit");
+        debugText += QString("Animation: %1\n").arg(m_flythroughActive ? "Active" : "Stopped");
+
+        m_debugInfoLabel->setText(debugText);
+    }
+}
+
+// Called by Qt3D when a frame is rendered
+bool ElevationView3D::event(QEvent* event)
+{
+    // Count frames for FPS calculation
+    if (event->type() == QEvent::UpdateRequest) {
+        m_frameCount++;
+    }
+
+    return QWidget::event(event);
+}
+
+void ElevationView3D::onTerrainDataReady(const TerrainData& data)
+{
+    logInfo("ElevationView3D", "Terrain data ready. Regenerating terrain mesh.");
+
+    // Safely clean up the old terrain entity
+    if (m_terrainEntity) {
+        m_terrainEntity->deleteLater();
+        m_terrainEntity = nullptr;
+    }
+
+    // Create the new terrain entity with the new data
+    m_terrainEntity = createTerrainMesh(data);
+    if (m_terrainEntity && m_rootEntity) {
+        m_terrainEntity->setParent(m_rootEntity);
+    }
+}

--- a/src/FlythroughController.cpp
+++ b/src/FlythroughController.cpp
@@ -1,0 +1,98 @@
+#include "FlythroughController.h"
+#include "logging.h"
+#include <QTimer>
+#include <Qt3DRender/QCamera>
+
+namespace {
+    constexpr int ANIMATION_INTERVAL_MS = 16; // ~60 FPS
+    constexpr float DEFAULT_SPEED = 0.001f; // Progress per update
+    constexpr float CAMERA_HEIGHT_OFFSET = 1.8f; // meters above track
+}
+
+FlythroughController::FlythroughController(RouteData* routeData, Qt3DRender::QCamera* camera, QObject* parent)
+    : QObject(parent),
+      m_routeData(routeData),
+      m_camera(camera),
+      m_timer(new QTimer(this)),
+      m_isActive(false),
+      m_progress(0.0f),
+      m_speed(DEFAULT_SPEED)
+{
+    logDebug("FlythroughController", "Creating controller.");
+    connect(m_timer, &QTimer::timeout, this, &FlythroughController::updateAnimation);
+}
+
+FlythroughController::~FlythroughController()
+{
+    logDebug("FlythroughController", "Destroying controller.");
+}
+
+void FlythroughController::start()
+{
+    logDebug("FlythroughController", "Start requested.");
+    if (m_progress >= 1.0f) {
+        m_progress = 0.0f;
+    }
+    m_isActive = true;
+    m_timer->start(ANIMATION_INTERVAL_MS);
+}
+
+void FlythroughController::pause()
+{
+    logDebug("FlythroughController", "Pause requested.");
+    if (m_isActive) {
+        m_isActive = false;
+        m_timer->stop();
+    }
+}
+
+void FlythroughController::stop()
+{
+    logDebug("FlythroughController", "Stop requested.");
+    m_isActive = false;
+    m_timer->stop();
+    m_progress = 0.0f;
+
+    // Manually move camera to the start position
+    if (m_routeData) {
+        RoutePoint startPoint = m_routeData->getPointAtProgress(0.0f);
+        QVector3D cameraPos = startPoint.position + QVector3D(0, CAMERA_HEIGHT_OFFSET, 0);
+        QVector3D lookTarget = cameraPos + startPoint.direction * 10.0f;
+        m_camera->setPosition(cameraPos);
+        m_camera->setViewCenter(lookTarget);
+    }
+
+    emit positionChanged(0);
+}
+
+void FlythroughController::setSpeed(float speed)
+{
+    logDebug("FlythroughController", QString("Set speed to %1.").arg(speed));
+    // The input speed is a multiplier, e.g., 1.0f is normal speed
+    m_speed = DEFAULT_SPEED * speed;
+}
+
+void FlythroughController::updateAnimation()
+{
+    if (!m_isActive) {
+        return;
+    }
+
+    m_progress += m_speed;
+    if (m_progress >= 1.0f) {
+        stop();
+        return;
+    }
+
+    RoutePoint currentPoint = m_routeData->getPointAtProgress(m_progress);
+
+    // Update camera
+    QVector3D cameraPos = currentPoint.position + QVector3D(0, CAMERA_HEIGHT_OFFSET, 0);
+    QVector3D lookTarget = cameraPos + currentPoint.direction * 10.0f; // Look 10m ahead
+    m_camera->setPosition(cameraPos);
+    m_camera->setViewCenter(lookTarget);
+
+    // Emit positionChanged with the correct point index.
+    size_t currentIndex = m_routeData->getIndexAtProgress(m_progress);
+    emit positionChanged(static_cast<int>(currentIndex));
+}

--- a/src/RouteData.cpp
+++ b/src/RouteData.cpp
@@ -1,0 +1,131 @@
+#include "RouteData.h"
+#include "logging.h"
+#include <cmath>
+#include <QVector2D>
+
+namespace {
+    // Constants for coordinate conversion
+    constexpr double EARTH_RADIUS_METERS = 6378137.0;
+
+    // Function to convert latitude/longitude to local X/Z coordinates using Mercator projection
+    QVector2D lonLatToMercator(double lon, double lat, double originLon, double originLat) {
+        double x = EARTH_RADIUS_METERS * (lon - originLon) * (M_PI / 180.0) * std::cos(originLat * (M_PI / 180.0));
+        double z = EARTH_RADIUS_METERS * (lat - originLat) * (M_PI / 180.0);
+        return QVector2D(static_cast<float>(x), static_cast<float>(z));
+    }
+}
+
+RouteData::RouteData(const std::vector<TrackPoint>& trackPoints, float elevationScale) {
+    logDebug("RouteData", "Processing track points...");
+    if (!trackPoints.empty()) {
+        processPoints(trackPoints, elevationScale);
+        logInfo("RouteData", QString("Successfully processed %1 points.").arg(trackPoints.size()));
+    } else {
+        logWarning("RouteData", "Track points vector is empty, nothing to process.");
+    }
+}
+
+RouteData::~RouteData() {
+    logDebug("RouteData", "Destroying RouteData object.");
+}
+
+void RouteData::processPoints(const std::vector<TrackPoint>& trackPoints, float elevationScale) {
+    m_positions.clear();
+    m_positions.reserve(trackPoints.size());
+    m_routePoints.clear();
+    m_routePoints.reserve(trackPoints.size());
+    m_totalDistance = 0.0f;
+
+    if (trackPoints.empty()) {
+        return;
+    }
+
+    // First pass: convert all points to local 3D coordinates
+    const double originLon = trackPoints.front().coord.longitude();
+    const double originLat = trackPoints.front().coord.latitude();
+    for (const auto& point : trackPoints) {
+        QVector2D mercatorCoords = lonLatToMercator(
+            point.coord.longitude(), point.coord.latitude(), originLon, originLat);
+        float elevation = static_cast<float>(point.elevation) * elevationScale;
+        m_positions.emplace_back(mercatorCoords.x(), elevation, mercatorCoords.y());
+    }
+
+    // Second pass: calculate distances and directions
+    for (size_t i = 0; i < m_positions.size(); ++i) {
+        RoutePoint rp;
+        rp.position = m_positions[i];
+
+        if (i > 0) {
+            m_totalDistance += (m_positions[i] - m_positions[i-1]).length();
+        }
+        rp.distance = m_totalDistance;
+
+        if (i < m_positions.size() - 1) {
+            rp.direction = (m_positions[i+1] - m_positions[i]).normalized();
+        } else if (m_positions.size() > 1) {
+            rp.direction = (m_positions[i] - m_positions[i-1]).normalized();
+        } else {
+            rp.direction = QVector3D(1, 0, 0); // Default direction
+        }
+        m_routePoints.push_back(rp);
+    }
+}
+
+RoutePoint RouteData::getPointAtProgress(float progress) const
+{
+    if (m_routePoints.empty()) {
+        return RoutePoint();
+    }
+
+    const float targetDistance = progress * m_totalDistance;
+
+    // Find the segment that contains the target distance
+    size_t segmentEnd = 1;
+    while (segmentEnd < m_routePoints.size() && m_routePoints[segmentEnd].distance < targetDistance) {
+        segmentEnd++;
+    }
+    if (segmentEnd >= m_routePoints.size()) {
+        return m_routePoints.back();
+    }
+
+    const size_t segmentStart = segmentEnd - 1;
+
+    const RoutePoint& p1 = m_routePoints[segmentStart];
+    const RoutePoint& p2 = m_routePoints[segmentEnd];
+
+    // Interpolate between the two points
+    const float segmentLength = p2.distance - p1.distance;
+    if (segmentLength < 0.001f) {
+        return p1; // Avoid division by zero
+    }
+
+    const float segmentProgress = (targetDistance - p1.distance) / segmentLength;
+
+    RoutePoint result;
+    result.position = p1.position + (p2.position - p1.position) * segmentProgress;
+    result.direction = (p1.direction + (p2.direction - p1.direction) * segmentProgress).normalized();
+    result.distance = targetDistance;
+
+    return result;
+}
+
+size_t RouteData::getIndexAtProgress(float progress) const
+{
+    if (m_routePoints.empty()) {
+        return 0;
+    }
+
+    const float targetDistance = progress * m_totalDistance;
+
+    // Find the segment that contains the target distance
+    size_t segmentEnd = 1;
+    while (segmentEnd < m_routePoints.size() && m_routePoints[segmentEnd].distance < targetDistance) {
+        segmentEnd++;
+    }
+    if (segmentEnd >= m_routePoints.size()) {
+        return m_routePoints.size() - 1;
+    }
+
+    // Return the index of the point that starts the segment.
+    return segmentEnd - 1;
+}

--- a/src/RouteRenderer.cpp
+++ b/src/RouteRenderer.cpp
@@ -1,0 +1,157 @@
+#include "RouteRenderer.h"
+#include "logging.h"
+#include <cmath>
+
+#include <Qt3DRender/QGeometry>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <Qt3DRender/QGeometryRenderer>
+#include <Qt3DExtras/QPhongMaterial>
+
+namespace {
+    // Configuration for the route mesh
+    const float ROUTE_RADIUS = 0.5f; // meters
+    const int ROUTE_SEGMENT_SIDES = 8; // An octagon cross-section is a good balance
+}
+
+RouteRenderer::RouteRenderer(RouteData* routeData, Qt3DCore::QEntity* parentEntity)
+    : m_routeData(routeData), m_entity(new Qt3DCore::QEntity(parentEntity))
+{
+    logDebug("RouteRenderer", "Creating renderer and generating mesh.");
+    generateMesh();
+}
+
+RouteRenderer::~RouteRenderer()
+{
+    logDebug("RouteRenderer", "Destroying renderer.");
+    // The entity will be cleaned up by its parent.
+}
+
+void RouteRenderer::generateMesh()
+{
+    if (!m_routeData || m_routeData->getPositions().size() < 2) {
+        logWarning("RouteRenderer", "Not enough data to generate a mesh.");
+        return;
+    }
+
+    auto geometry = new Qt3DRender::QGeometry(m_entity);
+
+    QByteArray vertexBufferData;
+    QByteArray indexBufferData;
+
+    const auto& positions = m_routeData->getPositions();
+    const int numPoints = positions.size();
+    const int numVertices = numPoints * ROUTE_SEGMENT_SIDES;
+    const int numIndices = (numPoints - 1) * ROUTE_SEGMENT_SIDES * 2 * 3; // (num segments) * (sides) * (2 triangles per side) * (3 vertices per triangle)
+
+    logDebug("RouteRenderer", QString("Generating mesh with %1 vertices and %2 indices.").arg(numVertices).arg(numIndices));
+
+    vertexBufferData.resize(numVertices * (3 + 3) * sizeof(float)); // 3 for pos, 3 for normal
+    float* p = reinterpret_cast<float*>(vertexBufferData.data());
+
+    indexBufferData.resize(numIndices * sizeof(unsigned int));
+    unsigned int* indices = reinterpret_cast<unsigned int*>(indexBufferData.data());
+
+    QVector3D lastUpVector(0.0f, 1.0f, 0.0f);
+
+    // Generate vertices
+    for (int i = 0; i < numPoints; ++i) {
+        QVector3D currentPoint = positions[i];
+        QVector3D direction;
+
+        if (i < numPoints - 1) {
+            direction = (positions[i+1] - currentPoint).normalized();
+        } else {
+            direction = (currentPoint - positions[i-1]).normalized();
+        }
+
+        // Create a coordinate system (tangent, bitangent, normal) for the current point
+        QVector3D right = QVector3D::crossProduct(direction, lastUpVector).normalized();
+        QVector3D up = QVector3D::crossProduct(right, direction).normalized();
+        lastUpVector = up;
+
+        // Generate a circle of vertices around the point
+        for (int j = 0; j < ROUTE_SEGMENT_SIDES; ++j) {
+            float angle = (float)j / ROUTE_SEGMENT_SIDES * 2.0f * M_PI;
+            QVector3D normal = (right * std::cos(angle) + up * std::sin(angle)).normalized();
+            QVector3D vertexPos = currentPoint + normal * ROUTE_RADIUS;
+
+            // Position
+            *p++ = vertexPos.x();
+            *p++ = vertexPos.y();
+            *p++ = vertexPos.z();
+
+            // Normal
+            *p++ = normal.x();
+            *p++ = normal.y();
+            *p++ = normal.z();
+        }
+    }
+
+    // Generate indices
+    for (int i = 0; i < numPoints - 1; ++i) {
+        for (int j = 0; j < ROUTE_SEGMENT_SIDES; ++j) {
+            unsigned int i0 = i * ROUTE_SEGMENT_SIDES + j;
+            unsigned int i1 = i * ROUTE_SEGMENT_SIDES + ((j + 1) % ROUTE_SEGMENT_SIDES);
+            unsigned int i2 = (i + 1) * ROUTE_SEGMENT_SIDES + j;
+            unsigned int i3 = (i + 1) * ROUTE_SEGMENT_SIDES + ((j + 1) % ROUTE_SEGMENT_SIDES);
+
+            // Triangle 1
+            *indices++ = i0;
+            *indices++ = i2;
+            *indices++ = i1;
+
+            // Triangle 2
+            *indices++ = i1;
+            *indices++ = i2;
+            *indices++ = i3;
+        }
+    }
+
+    auto* vertexBuffer = new Qt3DRender::QBuffer(geometry);
+    vertexBuffer->setData(vertexBufferData);
+
+    auto* indexBuffer = new Qt3DRender::QBuffer(geometry);
+    indexBuffer->setData(indexBufferData);
+
+    // Position attribute
+    auto* posAttr = new Qt3DRender::QAttribute(geometry);
+    posAttr->setName(Qt3DRender::QAttribute::defaultPositionAttributeName());
+    posAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    posAttr->setVertexSize(3);
+    posAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    posAttr->setBuffer(vertexBuffer);
+    posAttr->setByteStride(6 * sizeof(float));
+    posAttr->setCount(numVertices);
+    geometry->addAttribute(posAttr);
+
+    // Normal attribute
+    auto* normAttr = new Qt3DRender::QAttribute(geometry);
+    normAttr->setName(Qt3DRender::QAttribute::defaultNormalAttributeName());
+    normAttr->setVertexBaseType(Qt3DRender::QAttribute::Float);
+    normAttr->setVertexSize(3);
+    normAttr->setAttributeType(Qt3DRender::QAttribute::VertexAttribute);
+    normAttr->setBuffer(vertexBuffer);
+    normAttr->setByteOffset(3 * sizeof(float));
+    normAttr->setByteStride(6 * sizeof(float));
+    normAttr->setCount(numVertices);
+    geometry->addAttribute(normAttr);
+
+    // Index attribute
+    auto* indexAttr = new Qt3DRender::QAttribute(geometry);
+    indexAttr->setAttributeType(Qt3DRender::QAttribute::IndexAttribute);
+    indexAttr->setBuffer(indexBuffer);
+    indexAttr->setVertexBaseType(Qt3DRender::QAttribute::UnsignedInt);
+    indexAttr->setCount(numIndices);
+    geometry->addAttribute(indexAttr);
+
+    auto* renderer = new Qt3DRender::QGeometryRenderer();
+    renderer->setGeometry(geometry);
+    renderer->setPrimitiveType(Qt3DRender::QGeometryRenderer::Triangles);
+
+    auto* material = new Qt3DExtras::QPhongMaterial();
+    material->setDiffuse(QColor(QRgb(0x4CAF50))); // A nice green color
+
+    m_entity->addComponent(renderer);
+    m_entity->addComponent(material);
+}

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -1,0 +1,5 @@
+#include "build_info.h"
+#include <QString>
+
+// Define build timestamp for version tracking
+const QString BUILD_TIMESTAMP = __DATE__ " " __TIME__;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,6 @@
 #include <QTimer>
 #include <QDateTime>
 
-// Define build timestamp for version tracking (implementation of extern variable)
-const QString BUILD_TIMESTAMP = __DATE__ " " __TIME__;
-
 /**
  * Initialize application-specific folders and settings
  */

--- a/tests/flythroughcontroller_test.cpp
+++ b/tests/flythroughcontroller_test.cpp
@@ -1,0 +1,67 @@
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <Qt3DRender/QCamera>
+#include "FlythroughController.h"
+#include "RouteData.h"
+
+class FlythroughControllerTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    std::vector<TrackPoint> createSampleTrack() {
+        std::vector<TrackPoint> points;
+        points.push_back({QGeoCoordinate(34.0, -118.0, 100.0), 100.0, 0.0});
+        points.push_back({QGeoCoordinate(34.0, -117.0, 110.0), 110.0, 100000.0});
+        points.push_back({QGeoCoordinate(35.0, -118.0, 120.0), 120.0, 200000.0});
+        return points;
+    }
+
+private slots:
+    void testStartStop();
+    void testSignalEmitted();
+};
+
+void FlythroughControllerTest::testStartStop()
+{
+    auto points = createSampleTrack();
+    RouteData routeData(points);
+    auto camera = new Qt3DRender::QCamera();
+    FlythroughController controller(&routeData, camera);
+
+    QVector3D initialPos = camera->position();
+
+    controller.start();
+    QTest::qWait(100); // Let it run for a few frames
+
+    QVector3D movedPos = camera->position();
+    QVERIFY(movedPos != initialPos); // Verify position changed during animation
+
+    controller.stop();
+
+    // After stop, the camera should be at the start of the route (progress = 0)
+    RoutePoint startPoint = routeData.getPointAtProgress(0.0f);
+    QVector3D expectedStartPos = startPoint.position + QVector3D(0, 1.8f, 0); // 1.8f is CAMERA_HEIGHT_OFFSET
+
+    // Using QVERIFY with a tolerance for floating point comparisons
+    QVERIFY(camera->position().distanceToPoint(expectedStartPos) < 0.001f);
+}
+
+void FlythroughControllerTest::testSignalEmitted()
+{
+    auto points = createSampleTrack();
+    RouteData routeData(points);
+    auto camera = new Qt3DRender::QCamera();
+    FlythroughController controller(&routeData, camera);
+
+    QSignalSpy spy(&controller, &FlythroughController::positionChanged);
+
+    controller.start();
+    QTest::qWait(200);
+    controller.stop();
+
+    QVERIFY(spy.count() > 0); // At least one signal should have been emitted
+}
+
+QTEST_MAIN(FlythroughControllerTest)
+#include "flythroughcontroller_test.moc"

--- a/tests/routedata_test.cpp
+++ b/tests/routedata_test.cpp
@@ -1,0 +1,60 @@
+#include <QtTest/QtTest>
+#include "RouteData.h"
+#include "GpxParser.h" // For TrackPoint definition
+
+class RouteDataTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testEmptyData();
+    void testProcessPoints();
+};
+
+void RouteDataTest::testEmptyData()
+{
+    std::vector<TrackPoint> points;
+    RouteData data(points);
+
+    QVERIFY(data.getPositions().empty());
+}
+
+void RouteDataTest::testProcessPoints()
+{
+    // Create a sample track
+    std::vector<TrackPoint> points;
+    // Point 1: Origin
+    points.push_back({QGeoCoordinate(34.0, -118.0, 100.0), 100.0, 0.0});
+    // Point 2: About 1 degree east
+    points.push_back({QGeoCoordinate(34.0, -117.0, 110.0), 110.0, 100000.0});
+    // Point 3: About 1 degree north
+    points.push_back({QGeoCoordinate(35.0, -118.0, 120.0), 120.0, 200000.0});
+
+
+    RouteData data(points);
+
+    const auto& positions = data.getPositions();
+    QCOMPARE(positions.size(), (size_t)3);
+
+    // Check origin point (should be at 0, 100, 0)
+    QCOMPARE(positions[0].x(), 0.0f);
+    QCOMPARE(positions[0].y(), 100.0f);
+    QCOMPARE(positions[0].z(), 0.0f);
+
+    // Check second point (roughly)
+    // Mercator projection is not linear, so we check for approximate values.
+    // At 34 degrees latitude, 1 degree of longitude is roughly 92.4km.
+    QVERIFY(positions[1].x() > 92000.0f && positions[1].x() < 93000.0f);
+    QCOMPARE(positions[1].y(), 110.0f);
+    QVERIFY(std::abs(positions[1].z()) < 1.0f); // Should be very close to 0 on Z axis
+
+    // Check third point (roughly)
+    // 1 degree of latitude is roughly 111.32km.
+    QVERIFY(std::abs(positions[2].x()) < 1.0f); // Should be very close to 0 on X axis
+    QCOMPARE(positions[2].y(), 120.0f);
+    QVERIFY(positions[2].z() > 111000.0f && positions[2].z() < 112000.0f);
+}
+
+
+QTEST_MAIN(RouteDataTest)
+#include "routedata_test.moc"


### PR DESCRIPTION
Adds extensive logging to the ElevationView3D and RouteRenderer classes to help diagnose a visual issue where the 3D scene is not appearing.

This logging will trace:
- The number of vertices and indices generated for the route mesh.
- The calculated bounding box of the route.
- The final camera position and view center.